### PR TITLE
fix: rename ios_url/android_url to ios_app_store_url/android_app_store_url

### DIFF
--- a/src/lib/fingerprint.ts
+++ b/src/lib/fingerprint.ts
@@ -375,8 +375,8 @@ export async function recordInstallEvent(
       `SELECT
          short_code,
          original_url,
-         ios_url,
-         android_url,
+         ios_app_store_url,
+         android_app_store_url,
          web_fallback_url,
          utm_parameters,
          targeting_rules,
@@ -391,8 +391,8 @@ export async function recordInstallEvent(
       deepLinkData = {
         shortCode: link.short_code,
         originalUrl: link.original_url,
-        iosUrl: link.ios_url,
-        androidUrl: link.android_url,
+        iosUrl: link.ios_app_store_url,
+        androidUrl: link.android_app_store_url,
         webFallbackUrl: link.web_fallback_url,
         utmParameters: link.utm_parameters,
         targetingRules: link.targeting_rules,

--- a/src/routes/debug.ts
+++ b/src/routes/debug.ts
@@ -109,12 +109,12 @@ export async function debugRoutes(fastify: FastifyInstance) {
     let redirectUrl = link.original_url;
     let redirectReason = 'original_url (default)';
 
-    if (deviceType === 'ios' && link.ios_url) {
-      redirectUrl = link.ios_url;
-      redirectReason = 'ios_url (iOS device detected)';
-    } else if (deviceType === 'android' && link.android_url) {
-      redirectUrl = link.android_url;
-      redirectReason = 'android_url (Android device detected)';
+    if (deviceType === 'ios' && link.ios_app_store_url) {
+      redirectUrl = link.ios_app_store_url;
+      redirectReason = 'ios_app_store_url (iOS device detected)';
+    } else if (deviceType === 'android' && link.android_app_store_url) {
+      redirectUrl = link.android_app_store_url;
+      redirectReason = 'android_app_store_url (Android device detected)';
     } else if (deviceType === 'web' && link.web_fallback_url) {
       redirectUrl = link.web_fallback_url;
       redirectReason = 'web_fallback_url (Web device detected)';

--- a/src/routes/sdk.ts
+++ b/src/routes/sdk.ts
@@ -114,8 +114,8 @@ export async function sdkRoutes(fastify: FastifyInstance) {
            ie.*,
            l.short_code,
            l.original_url,
-           l.ios_url,
-           l.android_url,
+           l.ios_app_store_url,
+           l.android_app_store_url,
            l.web_fallback_url,
            l.utm_parameters,
            l.deep_link_parameters
@@ -171,8 +171,8 @@ export async function sdkRoutes(fastify: FastifyInstance) {
           ? {
               shortCode: install.short_code,
               originalUrl: install.original_url,
-              iosUrl: install.ios_url,
-              androidUrl: install.android_url,
+              iosUrl: install.ios_app_store_url,
+              androidUrl: install.android_app_store_url,
               webFallbackUrl: install.web_fallback_url,
               utmParameters: install.utm_parameters,
               deepLinkParameters: install.deep_link_parameters,


### PR DESCRIPTION
## Summary
- Fixes `column 'ios_url' of relation 'links' does not exist` error when creating links
- Updates SQL queries and property accesses in `debug.ts`, `sdk.ts`, and `fingerprint.ts` to use renamed column names (`ios_app_store_url`, `android_app_store_url`)
- Column rename migration already existed but queries were never updated

Closes SIT-51

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — all 20 tests pass
- [ ] Manual test: create a link with iOS/Android app store URLs — verify no column error