### PR TITLE
Add request ID propagation to server logs and responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify, { FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
 import redis from '@fastify/redis';
+import { randomUUID } from 'crypto';
 import { initializeDatabase, DatabaseOptions } from './lib/database.js';
 import { redirectRoutes } from './routes/redirect.js';
 import { linkRoutes } from './routes/links.js';
@@ -25,6 +26,11 @@ export interface ServerOptions {
 export async function createServer(options: ServerOptions = {}) {
   const fastify = Fastify({
     logger: options.logger !== undefined ? options.logger : true,
+    genReqId: (req) => (req.headers['x-request-id'] as string) || randomUUID(),
+  });
+
+  fastify.addHook('onSend', async (request, reply) => {
+    reply.header('x-request-id', request.id);
   });
 
   // CORS


### PR DESCRIPTION
## Description

Attaches a unique request ID to every HTTP request, honoring inbound `x-request-id` headers and echoing the ID back in responses. This makes distributed tracing and log correlation straightforward.

## Type of Change

<!-- Put an 'x' in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition or update

## Changes Made

- Use inbound `x-request-id` header as the request ID when present, otherwise generate a UUID
- Added `onSend` hook to echo the resolved request ID back via `x-request-id` response header

## Testing

- [x] Tests pass locally (`npm test`)
- [ ] New tests added for new functionality
- [ ] Existing tests updated (if needed)
- [x] Type checking passes (`npm run typecheck`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have used conventional commit messages (e.g., `feat:`, `fix:`)
- [x] I have signed the [Contributor License Agreement](../CLA.md) (the CLA bot will prompt you)

## Breaking Changes

**None**

## Additional Notes

### Why It Was Needed
Without a consistent request ID, correlating log entries across services (or debugging a specific client request) required guesswork. Propagating and reflecting the `x-request-id` header is a standard observability practice.
