### PR TITLE
Add graceful shutdown handler for SIGTERM and SIGINT

### DIFF
--- a/examples/basic-server.ts
+++ b/examples/basic-server.ts
@@ -1,4 +1,4 @@
-import { createServer } from '@linkforty/core';
+import { createServer, registerGracefulShutdown } from '@linkforty/core';
 
 async function start() {
   const server = await createServer({
@@ -17,6 +17,8 @@ async function start() {
     port: Number(process.env.PORT) || 3000,
     host: '0.0.0.0',
   });
+
+  registerGracefulShutdown(server);
 
   console.log('LinkForty server running on http://localhost:3000');
   console.log('');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Fastify, { FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
 import redis from '@fastify/redis';
-import { initializeDatabase, DatabaseOptions } from './lib/database.js';
+import { initializeDatabase, DatabaseOptions, db } from './lib/database.js';
 import { redirectRoutes } from './routes/redirect.js';
 import { linkRoutes } from './routes/links.js';
 import { analyticsRoutes } from './routes/analytics.js';
@@ -53,6 +53,24 @@ export async function createServer(options: ServerOptions = {}) {
   await fastify.register(qrRoutes);
 
   return fastify;
+}
+
+export function registerGracefulShutdown(fastify: FastifyInstance): void {
+  const shutdown = async (signal: string) => {
+    fastify.log.info(`Received ${signal}, shutting down gracefully`);
+    try {
+      await fastify.close();
+      await db.end();
+      fastify.log.info('Shutdown complete');
+      process.exit(0);
+    } catch (err) {
+      fastify.log.error(err, 'Error during shutdown');
+      process.exit(1);
+    }
+  };
+
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
 }
 
 // Re-export utilities and types


### PR DESCRIPTION
## Description

Introduces a `registerGracefulShutdown` utility that cleanly closes the Fastify server and database pool on process termination signals, preventing in-flight requests and connections from being dropped abruptly.

### Benefits
- Clean teardown prevents leaked database connections in containerized environments
- Logs shutdown progress and errors for easier observability
- Simple one-call API makes it easy to adopt in any server setup

## Type of Change

<!-- Put an 'x' in the boxes that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring
- [x] ⚡ Performance improvement
- [ ] ✅ Test addition or update

## Changes Made

- Added `registerGracefulShutdown(fastify)` function to `src/index.ts` that handles `SIGTERM` and `SIGINT`
- Shutdown sequence closes the Fastify server first, then ends the database pool, then exits with code 0 (or 1 on error)
- Exported `db` from `database.ts` to allow pool teardown during shutdown
- Updated `examples/basic-server.ts` to demonstrate usage of the new function

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] Tests pass locally (`npm test`)
- [ ] New tests added for new functionality
- [ ] Existing tests updated (if needed)
- [x] Type checking passes (`npm run typecheck`)

## Checklist

<!-- Put an 'x' in the boxes that apply -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have used conventional commit messages (e.g., `feat:`, `fix:`)
- [x] I have signed the [Contributor License Agreement](../CLA.md) (the CLA bot will prompt you)

## Breaking Changes

<!-- If this is a breaking change, describe the migration path for existing users -->

**None** <!-- or describe the breaking changes -->