### PR TITLE
fix(cache): invalidate link resolution cache on update and delete

### DIFF
--- a/src/lib/link-resolution-cache.test.ts
+++ b/src/lib/link-resolution-cache.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { invalidateLinkResolutionCache } from './link-resolution-cache';
+
+describe('invalidateLinkResolutionCache', () => {
+  it('no-ops when redis is null', async () => {
+    await expect(invalidateLinkResolutionCache(null, 'abc')).resolves.toBeUndefined();
+  });
+
+  it('no-ops when redis is undefined', async () => {
+    await expect(invalidateLinkResolutionCache(undefined, 'abc')).resolves.toBeUndefined();
+  });
+
+  it('deletes legacy key when no templateSlug', async () => {
+    const del = vi.fn().mockResolvedValue(1);
+    await invalidateLinkResolutionCache({ del } as any, 'abc');
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith('link:abc');
+  });
+
+  it('deletes both legacy and template keys when templateSlug is provided', async () => {
+    const del = vi.fn().mockResolvedValue(2);
+    await invalidateLinkResolutionCache({ del } as any, 'abc', 'mytemplate');
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith('link:abc', 'link:mytemplate:abc');
+  });
+
+  it('skips template key when templateSlug is null', async () => {
+    const del = vi.fn().mockResolvedValue(1);
+    await invalidateLinkResolutionCache({ del } as any, 'abc', null);
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith('link:abc');
+  });
+
+  it('skips template key when templateSlug is empty string', async () => {
+    const del = vi.fn().mockResolvedValue(1);
+    await invalidateLinkResolutionCache({ del } as any, 'abc', '');
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledWith('link:abc');
+  });
+
+  it('swallows errors from redis.del without throwing', async () => {
+    const del = vi.fn().mockRejectedValue(new Error('connection lost'));
+    await expect(invalidateLinkResolutionCache({ del } as any, 'abc')).resolves.toBeUndefined();
+    expect(del).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/link-resolution-cache.ts
+++ b/src/lib/link-resolution-cache.ts
@@ -1,0 +1,22 @@
+/**
+ * Invalidate the Redis cache entries used by the redirect and SDK resolve
+ * read paths for a given link. Safe to call when Redis is not configured.
+ *
+ * Cache key patterns (set in redirect.ts / sdk.ts):
+ *   link:${shortCode}
+ *   link:${templateSlug}:${shortCode}
+ */
+export async function invalidateLinkResolutionCache(
+  redis: { del(...keys: string[]): Promise<number> } | null | undefined,
+  shortCode: string,
+  templateSlug?: string | null,
+): Promise<void> {
+  if (!redis) return;
+  try {
+    const keys = [`link:${shortCode}`];
+    if (templateSlug) keys.push(`link:${templateSlug}:${shortCode}`);
+    await redis.del(...keys);
+  } catch {
+    // Swallow — a cache miss on the next read is self-healing.
+  }
+}

--- a/src/routes/links.ts
+++ b/src/routes/links.ts
@@ -2,6 +2,16 @@ import { FastifyInstance, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { db } from '../lib/database.js';
 import { generateShortCode } from '../lib/utils.js';
+import { invalidateLinkResolutionCache } from '../lib/link-resolution-cache.js';
+
+async function getTemplateSlug(templateId: string | null): Promise<string | null> {
+  if (!templateId) return null;
+  const result = await db.query(
+    'SELECT slug FROM link_templates WHERE id = $1',
+    [templateId]
+  );
+  return result.rows[0]?.slug ?? null;
+}
 
 const createLinkSchema = z.object({
   userId: z.string().uuid().optional(),
@@ -227,6 +237,12 @@ export async function linkRoutes(fastify: FastifyInstance) {
 
     const data = updateLinkSchema.parse(request.body);
 
+    // Capture current identifiers for cache invalidation after the update
+    const oldLinkResult = await db.query(
+      'SELECT short_code, template_id FROM links WHERE id = $1',
+      [id]
+    );
+
     // Build update query dynamically
     const updates: string[] = [];
     const values: any[] = [];
@@ -271,6 +287,16 @@ export async function linkRoutes(fastify: FastifyInstance) {
     }
 
     const link = result.rows[0];
+
+    // Invalidate cached link JSON for both old and new template associations
+    const oldRow = oldLinkResult.rows[0];
+    const oldTemplateSlug = await getTemplateSlug(oldRow?.template_id);
+    const newTemplateSlug = await getTemplateSlug(link.template_id);
+    await invalidateLinkResolutionCache(fastify.redis, link.short_code, oldTemplateSlug);
+    if (newTemplateSlug !== oldTemplateSlug) {
+      await invalidateLinkResolutionCache(fastify.redis, link.short_code, newTemplateSlug);
+    }
+
     return {
       ...link,
       utmParameters: link.utm_parameters,
@@ -388,12 +414,12 @@ export async function linkRoutes(fastify: FastifyInstance) {
     let result;
     if (userId) {
       result = await db.query(
-        'DELETE FROM links WHERE id = $1 AND user_id = $2 RETURNING id',
+        'DELETE FROM links WHERE id = $1 AND user_id = $2 RETURNING id, short_code, template_id',
         [id, userId]
       );
     } else {
       result = await db.query(
-        'DELETE FROM links WHERE id = $1 RETURNING id',
+        'DELETE FROM links WHERE id = $1 RETURNING id, short_code, template_id',
         [id]
       );
     }
@@ -401,6 +427,10 @@ export async function linkRoutes(fastify: FastifyInstance) {
     if (result.rows.length === 0) {
       throw new Error('Link not found');
     }
+
+    const deleted = result.rows[0];
+    const templateSlug = await getTemplateSlug(deleted.template_id);
+    await invalidateLinkResolutionCache(fastify.redis, deleted.short_code, templateSlug);
 
     return { success: true };
   });


### PR DESCRIPTION
- Add reusable helper for Redis link-resolution cache invalidation
- Invalidate cached keys after successful link update and delete
- Clear both old and new key sets when template association changes
- Add unit tests for cache invalidation helper behavior

## Description

Fix stale redirect and SDK resolve behavior by invalidating Redis link-resolution cache entries when links are updated or deleted.

Previously, the read path cached link JSON for 5 minutes, but link mutation routes did not invalidate those keys. This meant stale redirects or stale SDK resolutions could be served until TTL expiry.

This change adds a small reusable cache invalidation helper and applies it to link update/delete flows.

## Type of Change

- [x] Bug fix / correctness improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Add `invalidateLinkResolutionCache` helper for Redis link-resolution cache keys
- Invalidate cached link-resolution keys after successful link update
- Invalidate both old and new key sets when template association changes
- Invalidate cached link-resolution keys after successful link delete
- Add unit tests for cache invalidation helper behavior

## Notes

- Scope is intentionally minimal and correctness-focused
- Does not change redirect read-path behavior
- Does not include stampede protection, negative caching, or broader cache redesign

## Testing

- All tests passing locally