### PR TITLE
fix(fingerprint): use empty string fallback for missing client IP

### DIFF
--- a/src/lib/client-ip.test.ts
+++ b/src/lib/client-ip.test.ts
@@ -12,10 +12,10 @@ describe('getClientIp', () => {
     expect(getClientIp(request)).toBe('192.168.1.1');
   });
 
-  it('returns socket.remoteAddress when request.ip is undefined', () => {
+  it('returns raw.socket.remoteAddress when request.ip is undefined', () => {
     const request = {
       ip: undefined,
-      socket: { remoteAddress: '10.0.0.2' },
+      raw: { socket: { remoteAddress: '10.0.0.2' } },
     } as unknown as FastifyRequest;
     expect(getClientIp(request)).toBe('10.0.0.2');
   });
@@ -25,14 +25,14 @@ describe('getClientIp', () => {
     expect(getClientIp(request)).toBe('192.168.1.1');
   });
 
-  it('returns "unknown" when neither ip nor socket.remoteAddress is available', () => {
-    const request = { ip: undefined, socket: {} } as unknown as FastifyRequest;
-    expect(getClientIp(request)).toBe('unknown');
+  it('returns empty string when neither ip nor socket.remoteAddress is available', () => {
+    const request = { ip: undefined, raw: { socket: {} } } as unknown as FastifyRequest;
+    expect(getClientIp(request)).toBe('');
   });
 
-  it('returns "unknown" when request has no socket', () => {
-    const request = { ip: undefined } as unknown as FastifyRequest;
-    expect(getClientIp(request)).toBe('unknown');
+  it('returns empty string when request.raw has no socket', () => {
+    const request = { ip: undefined, raw: {} } as unknown as FastifyRequest;
+    expect(getClientIp(request)).toBe('');
   });
 });
 

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -8,11 +8,11 @@ import type { FastifyRequest } from 'fastify';
  * returns that trusted value.
  */
 export function getClientIp(request: FastifyRequest): string {
-  const ip = request.ip ?? (request as any).socket?.remoteAddress;
+  const ip = request.ip ?? request.raw.socket?.remoteAddress;
   if (ip && typeof ip === 'string') {
     // IPv6-mapped IPv4: ::ffff:192.168.1.1 -> 192.168.1.1
     if (ip.startsWith('::ffff:')) return ip.slice(7);
     return ip;
   }
-  return 'unknown';
+  return '';
 }


### PR DESCRIPTION
## Description

Small follow-up fix based on prior review feedback.

This change improves type safety in the client IP helper and corrects missing-IP fallback behavior so installs without an IP do not accidentally match on the IP fingerprint factor.

## Changes Made

- Replace `(request as any).socket?.remoteAddress` with `request.raw.socket?.remoteAddress`
- Replace `'unknown'` fallback with empty string `''`
- Update tests to reflect the new behavior

## Why this matters

Using `'unknown'` as a fallback is truthy and could allow two no-IP installs to match on the IP component of fingerprint scoring.

Returning `''` instead ensures the IP comparison is skipped when no trusted IP is available.

## Testing

- All tests passing locally