### PR TITLE
fix(redirect): browser-aware mobile fallback (SIT-163)

### DIFF
--- a/src/routes/redirect.test.ts
+++ b/src/routes/redirect.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isIOSInAppBrowser,
+  isAndroidInAppBrowser,
+  pickMobileFallbackUrl,
+} from './redirect.js';
+
+// Real-world UA strings (truncated where helpful) for use across test cases.
+const UA = {
+  // Regular browsers — should NOT be detected as in-app
+  iosSafari:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+  iosChrome:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/123.0.6312.52 Mobile/15E148 Safari/604.1',
+  androidChrome:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
+  androidFirefox:
+    'Mozilla/5.0 (Android 14; Mobile; rv:125.0) Gecko/125.0 Firefox/125.0',
+
+  // iOS in-app browsers
+  iosGmail:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 GSA/322.0.616052181 Safari/604.1',
+  iosFacebook:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/450.0.0.0]',
+  iosInstagram:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 320.0.0.0',
+  iosOutlook:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Outlook-iOS/2.0',
+  iosTwitter:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Twitter for iPhone/10.0',
+
+  // Android in-app browsers
+  androidWebview:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile Safari/537.36',
+  androidFacebook:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/450.0.0.0]',
+  androidInstagram:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36 Instagram 320.0.0.0',
+  androidLine:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36 Line/13.0.0',
+  androidWhatsapp:
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36 WhatsApp/2.24.0',
+};
+
+const URLS = {
+  iosStore: 'https://apps.apple.com/app/example/id123',
+  androidStore: 'https://play.google.com/store/apps/details?id=com.example',
+  webFallback: 'https://example.com/landing',
+};
+
+describe('isIOSInAppBrowser', () => {
+  it('detects Gmail (GSA token)', () => {
+    expect(isIOSInAppBrowser(UA.iosGmail)).toBe(true);
+  });
+  it('detects Facebook (FBAN/FBAV)', () => {
+    expect(isIOSInAppBrowser(UA.iosFacebook)).toBe(true);
+  });
+  it('detects Instagram', () => {
+    expect(isIOSInAppBrowser(UA.iosInstagram)).toBe(true);
+  });
+  it('detects Outlook', () => {
+    expect(isIOSInAppBrowser(UA.iosOutlook)).toBe(true);
+  });
+  it('detects Twitter', () => {
+    expect(isIOSInAppBrowser(UA.iosTwitter)).toBe(true);
+  });
+  it('does not flag Safari as in-app', () => {
+    expect(isIOSInAppBrowser(UA.iosSafari)).toBe(false);
+  });
+  it('does not flag Chrome on iOS as in-app', () => {
+    expect(isIOSInAppBrowser(UA.iosChrome)).toBe(false);
+  });
+});
+
+describe('isAndroidInAppBrowser', () => {
+  it('detects generic Android WebView via wv) marker', () => {
+    expect(isAndroidInAppBrowser(UA.androidWebview)).toBe(true);
+  });
+  it('detects Facebook (FB_IAB/FBAN/FBAV)', () => {
+    expect(isAndroidInAppBrowser(UA.androidFacebook)).toBe(true);
+  });
+  it('detects Instagram', () => {
+    expect(isAndroidInAppBrowser(UA.androidInstagram)).toBe(true);
+  });
+  it('detects Line', () => {
+    expect(isAndroidInAppBrowser(UA.androidLine)).toBe(true);
+  });
+  it('detects WhatsApp', () => {
+    expect(isAndroidInAppBrowser(UA.androidWhatsapp)).toBe(true);
+  });
+  it('does not flag Chrome as in-app', () => {
+    expect(isAndroidInAppBrowser(UA.androidChrome)).toBe(false);
+  });
+  it('does not flag Firefox as in-app', () => {
+    expect(isAndroidInAppBrowser(UA.androidFirefox)).toBe(false);
+  });
+});
+
+describe('pickMobileFallbackUrl — iOS regular browser (Safari/Chrome)', () => {
+  it('prefers iOS store URL over web fallback', () => {
+    const r = pickMobileFallbackUrl('ios', UA.iosSafari, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r).toEqual({ url: URLS.iosStore, reason: 'ios_app_store_url' });
+  });
+  it('falls back to web fallback when iOS store URL is absent', () => {
+    const r = pickMobileFallbackUrl('ios', UA.iosSafari, null, URLS.androidStore, URLS.webFallback);
+    expect(r).toEqual({ url: URLS.webFallback, reason: 'web_fallback_url' });
+  });
+  it('uses iOS store URL when web fallback is absent', () => {
+    const r = pickMobileFallbackUrl('ios', UA.iosSafari, URLS.iosStore, URLS.androidStore, null);
+    expect(r).toEqual({ url: URLS.iosStore, reason: 'ios_app_store_url' });
+  });
+  it('returns null when both iOS store URL and web fallback are absent', () => {
+    expect(pickMobileFallbackUrl('ios', UA.iosSafari, null, URLS.androidStore, null)).toBeNull();
+  });
+});
+
+describe('pickMobileFallbackUrl — iOS in-app browser (Gmail/FB/Instagram/etc.)', () => {
+  it('prefers web fallback over iOS store URL', () => {
+    const r = pickMobileFallbackUrl('ios', UA.iosGmail, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r).toEqual({ url: URLS.webFallback, reason: 'web_fallback_url' });
+  });
+  it('falls back to iOS store URL when web fallback is absent', () => {
+    const r = pickMobileFallbackUrl('ios', UA.iosGmail, URLS.iosStore, URLS.androidStore, null);
+    expect(r).toEqual({ url: URLS.iosStore, reason: 'ios_app_store_url' });
+  });
+  it('returns null when both iOS store URL and web fallback are absent', () => {
+    expect(pickMobileFallbackUrl('ios', UA.iosGmail, null, URLS.androidStore, null)).toBeNull();
+  });
+});
+
+describe('pickMobileFallbackUrl — Android regular browser (Chrome/Firefox)', () => {
+  it('prefers Android store URL over web fallback', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidChrome, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r).toEqual({ url: URLS.androidStore, reason: 'android_app_store_url' });
+  });
+  it('falls back to web fallback when Android store URL is absent', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidChrome, URLS.iosStore, null, URLS.webFallback);
+    expect(r).toEqual({ url: URLS.webFallback, reason: 'web_fallback_url' });
+  });
+  it('uses Android store URL when web fallback is absent', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidChrome, URLS.iosStore, URLS.androidStore, null);
+    expect(r).toEqual({ url: URLS.androidStore, reason: 'android_app_store_url' });
+  });
+  it('returns null when both Android store URL and web fallback are absent', () => {
+    expect(pickMobileFallbackUrl('android', UA.androidChrome, URLS.iosStore, null, null)).toBeNull();
+  });
+});
+
+describe('pickMobileFallbackUrl — Android in-app browser (FB/Instagram/Line/WebView)', () => {
+  it('prefers web fallback over Android store URL', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidFacebook, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r).toEqual({ url: URLS.webFallback, reason: 'web_fallback_url' });
+  });
+  it('detects WebView via wv) marker and prefers web fallback', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidWebview, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r).toEqual({ url: URLS.webFallback, reason: 'web_fallback_url' });
+  });
+  it('falls back to Android store URL when web fallback is absent', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidFacebook, URLS.iosStore, URLS.androidStore, null);
+    expect(r).toEqual({ url: URLS.androidStore, reason: 'android_app_store_url' });
+  });
+});
+
+describe('pickMobileFallbackUrl — reporter scenario regression test', () => {
+  // Reproduces SIT-163: user creates a link with iOS, Android, and web fallback URLs;
+  // mobile visitor expects the App/Play Store; previously got the web fallback.
+  it('iOS Safari → iOS App Store (was: web fallback)', () => {
+    const r = pickMobileFallbackUrl('ios', UA.iosSafari, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r?.url).toBe(URLS.iosStore);
+    expect(r?.reason).toBe('ios_app_store_url');
+  });
+  it('Android Chrome → Play Store (was: web fallback)', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidChrome, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r?.url).toBe(URLS.androidStore);
+    expect(r?.reason).toBe('android_app_store_url');
+  });
+  // And the email-marketing flow that the prior fix protected stays correct:
+  it('iOS Gmail in-app → web fallback (preserves UL second-chance)', () => {
+    const r = pickMobileFallbackUrl('ios', UA.iosGmail, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r?.url).toBe(URLS.webFallback);
+  });
+  it('Android Facebook in-app → web fallback (preserves UL second-chance)', () => {
+    const r = pickMobileFallbackUrl('android', UA.androidFacebook, URLS.iosStore, URLS.androidStore, URLS.webFallback);
+    expect(r?.url).toBe(URLS.webFallback);
+  });
+});

--- a/src/routes/redirect.ts
+++ b/src/routes/redirect.ts
@@ -9,7 +9,7 @@ import { emitClickEvent } from '../lib/event-emitter.js';
  * Detect iOS in-app browsers where Universal Links don't fire.
  * These browsers use WKWebView which bypasses the Universal Links mechanism.
  */
-function isIOSInAppBrowser(userAgent: string): boolean {
+export function isIOSInAppBrowser(userAgent: string): boolean {
   const inAppPatterns = [
     /GSA\//i,              // Google Search App (Gmail in-app browser)
     /Gmail\//i,            // Gmail
@@ -22,6 +22,68 @@ function isIOSInAppBrowser(userAgent: string): boolean {
     /YahooMobile/i,        // Yahoo Mail
   ];
   return inAppPatterns.some(pattern => pattern.test(userAgent));
+}
+
+/**
+ * Detect Android in-app browsers where App Links don't fire.
+ * These browsers use Android WebView (or app-specific webviews) that bypass
+ * the App Link / Digital Asset Link mechanism.
+ */
+export function isAndroidInAppBrowser(userAgent: string): boolean {
+  const inAppPatterns = [
+    /FB_IAB|FBAN|FBAV/i,   // Facebook in-app browser
+    /Instagram/i,
+    /Line\//i,
+    /KAKAOTALK/i,
+    /Twitter/i,
+    /LinkedIn/i,
+    /MicroMessenger/i,     // WeChat
+    /Outlook-Android/i,
+    /WhatsApp/i,
+    /Pinterest/i,
+    /Telegram/i,
+    /Snapchat/i,
+    /\swv\)/,              // Generic Android WebView marker (e.g. "Mobile Safari/537.36; wv)")
+  ];
+  return inAppPatterns.some(pattern => pattern.test(userAgent));
+}
+
+/**
+ * Pick the destination URL for a mobile click that has fallen through the
+ * Universal Link / App Link / app_scheme priority steps. The choice depends on
+ * whether the click is from an in-app browser:
+ *
+ * - Regular browser (Safari, Chrome): the OS-level UL/App Link check ran and
+ *   didn't fire, so the app must not be installed → prefer the App/Play Store URL.
+ *
+ * - In-app browser (Gmail, GSA, FB, Instagram, Outlook, etc.): UL is bypassed
+ *   regardless of install state, so we don't know if the app is installed →
+ *   prefer the web fallback URL, which gives the OS another chance to fire UL
+ *   if the fallback is on the app's UL/App-Link domain.
+ *
+ * Returns null if no URL is available (caller should fall back to original_url).
+ */
+export function pickMobileFallbackUrl(
+  device: 'ios' | 'android',
+  userAgent: string,
+  iosUrl: string | null,
+  androidUrl: string | null,
+  webFallbackUrl: string | null,
+): { url: string; reason: string } | null {
+  const inApp = device === 'ios'
+    ? isIOSInAppBrowser(userAgent)
+    : isAndroidInAppBrowser(userAgent);
+  const storeUrl = device === 'ios' ? iosUrl : androidUrl;
+  const storeReason = device === 'ios' ? 'ios_app_store_url' : 'android_app_store_url';
+
+  if (inApp) {
+    if (webFallbackUrl) return { url: webFallbackUrl, reason: 'web_fallback_url' };
+    if (storeUrl)       return { url: storeUrl,       reason: storeReason };
+  } else {
+    if (storeUrl)       return { url: storeUrl,       reason: storeReason };
+    if (webFallbackUrl) return { url: webFallbackUrl, reason: 'web_fallback_url' };
+  }
+  return null;
 }
 
 /**
@@ -273,15 +335,12 @@ export async function redirectRoutes(fastify: FastifyInstance) {
           } else if (link.app_scheme && link.deep_link_path) {
             redirectUrl = `${link.app_scheme}://${link.deep_link_path.replace(/^\//, '')}`;
             redirectReason = 'app_scheme';
-          } else if (webFallback) {
-            // Web fallback takes priority over store URL — if the fallback is on
-            // the app's Universal Link domain, iOS will open the app directly.
-            // If the app isn't installed, the fallback page shows store links.
-            redirectUrl = webFallback;
-            redirectReason = 'web_fallback_url';
-          } else if (iosStoreUrl) {
-            redirectUrl = iosStoreUrl;
-            redirectReason = 'ios_app_store_url';
+          } else {
+            const fb = pickMobileFallbackUrl('ios', userAgent, iosStoreUrl, androidStoreUrl, webFallback);
+            if (fb) {
+              redirectUrl = fb.url;
+              redirectReason = fb.reason;
+            }
           }
         } else if (deviceType === 'android') {
           if (link.android_app_link) {
@@ -290,12 +349,12 @@ export async function redirectRoutes(fastify: FastifyInstance) {
           } else if (link.app_scheme && link.deep_link_path) {
             redirectUrl = `${link.app_scheme}://${link.deep_link_path.replace(/^\//, '')}`;
             redirectReason = 'app_scheme';
-          } else if (webFallback) {
-            redirectUrl = webFallback;
-            redirectReason = 'web_fallback_url';
-          } else if (androidStoreUrl) {
-            redirectUrl = androidStoreUrl;
-            redirectReason = 'android_app_store_url';
+          } else {
+            const fb = pickMobileFallbackUrl('android', userAgent, iosStoreUrl, androidStoreUrl, webFallback);
+            if (fb) {
+              redirectUrl = fb.url;
+              redirectReason = fb.reason;
+            }
           }
         } else if (deviceType === 'web' && webFallback) {
           redirectUrl = webFallback;
@@ -393,44 +452,37 @@ export async function redirectRoutes(fastify: FastifyInstance) {
 
     if (device === 'ios') {
       // iOS Priority:
-      // 1. Universal Link (HTTPS URL with AASA file) - if app installed, opens app
-      // 2. URI scheme (myapp://path) - fallback when Universal Links fail
-      // 3. Web fallback URL - if on the app's Universal Link domain, iOS opens the app;
-      //    if app isn't installed, the page shows store download links
-      // 4. App Store URL (link → template → workspace) - direct store redirect
-      // 5. Original URL - ultimate fallback
-
+      // 1. Universal Link (HTTPS URL with AASA file) — if app installed, OS opens app
+      //    (this branch only runs when UL didn't fire upstream, e.g. in-app browser)
+      // 2. URI scheme (myapp://path) — explicit deep link
+      // 3. Mobile fallback (browser-aware):
+      //    - regular browser: App Store URL > web fallback URL
+      //      (UL would have fired if app installed, so app is not installed)
+      //    - in-app browser: web fallback URL > App Store URL
+      //      (UL was bypassed; web fallback gives UL a second chance to fire)
+      // 4. Original URL — ultimate fallback
       if (link.ios_universal_link) {
         redirectUrl = link.ios_universal_link;
       } else if (link.app_scheme && link.deep_link_path) {
         // Build URI scheme URL: myapp://product/123
         redirectUrl = `${link.app_scheme}://${link.deep_link_path.replace(/^\//, '')}`;
         useSchemeUrl = true;
-      } else if (webFallbackUrl) {
-        redirectUrl = webFallbackUrl;
-      } else if (iosUrl) {
-        redirectUrl = iosUrl;
+      } else {
+        const fb = pickMobileFallbackUrl('ios', userAgent, iosUrl, androidUrl, webFallbackUrl);
+        if (fb) redirectUrl = fb.url;
       }
 
     } else if (device === 'android') {
-      // Android Priority:
-      // 1. App Link (HTTPS URL with Digital Asset Links) - if app installed, opens app
-      // 2. URI scheme (myapp://path) - fallback when App Links fail
-      // 3. Web fallback URL - if on the app's App Link domain, Android opens the app;
-      //    if app isn't installed, the page shows store download links
-      // 4. Play Store URL (link → template → workspace) - direct store redirect
-      // 5. Original URL - ultimate fallback
-
+      // Android Priority — same logic as iOS, with android_app_link in place of UL
       if (link.android_app_link) {
         redirectUrl = link.android_app_link;
       } else if (link.app_scheme && link.deep_link_path) {
         // Build URI scheme URL: myapp://product/123
         redirectUrl = `${link.app_scheme}://${link.deep_link_path.replace(/^\//, '')}`;
         useSchemeUrl = true;
-      } else if (webFallbackUrl) {
-        redirectUrl = webFallbackUrl;
-      } else if (androidUrl) {
-        redirectUrl = androidUrl;
+      } else {
+        const fb = pickMobileFallbackUrl('android', userAgent, iosUrl, androidUrl, webFallbackUrl);
+        if (fb) redirectUrl = fb.url;
       }
 
     } else if (device === 'web') {
@@ -483,9 +535,12 @@ export async function redirectRoutes(fastify: FastifyInstance) {
       const schemeUrl = link.custom_scheme_url
         || `${link.app_scheme}://${deepPath}`;
 
-      const storeFallback = device === 'ios'
-        ? (iosUrl || webFallbackUrl || link.original_url)
-        : (androidUrl || webFallbackUrl || link.original_url);
+      // The interstitial JS tries the scheme first; storeFallback is what we
+      // navigate to if the scheme doesn't open the app within ~1.5s. Pick it
+      // browser-aware: regular browsers prefer the store URL, in-app browsers
+      // prefer the web fallback (gives UL a second chance to fire).
+      const fb = pickMobileFallbackUrl(device, userAgent, iosUrl, androidUrl, webFallbackUrl);
+      const storeFallback = fb?.url || link.original_url;
 
       if (storeFallback) {
         let fullSchemeUrl = schemeUrl;


### PR DESCRIPTION
## Summary

Mobile clicks that reach the redirect handler now go to the iOS App Store / Play Store URL when they come from a regular browser (Safari, Chrome), and to the web fallback URL when they come from an in-app browser (Gmail, GSA, Outlook, Facebook, Instagram, etc.). Previously, all mobile clicks were sent to the web fallback URL, which broke the OneLink-style mental model that customers expect.

## Why

In LinkForty's setup, the AASA / assetlinks files are hosted on the customer's vanity domain by us. iOS/Android perform the Universal Link / App Link check **before** any HTTP request reaches the backend. So when a mobile click does reach the backend:

- **Regular browser**: UL would have fired if the app were installed → it didn't → app is **not installed** → App Store URL is the right destination.
- **In-app browser**: UL is bypassed by the browser regardless of install state → we don't know if the app is installed → web fallback URL gives UL a second chance to fire (if the fallback is on the app's UL domain). This is what the email-marketing flow needs.

The prior priority order (`6345b99`, 2026-04-01) sent everyone to web fallback to protect the in-app-browser case. That broke the regular-browser case. This PR keeps both cases working by branching on user-agent.

## Changes

- New `isAndroidInAppBrowser()` [[1]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R32-R49) (sibling of the existing `isIOSInAppBrowser` [[2]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R12-R25), which was defined but never wired up). Detects FB / Instagram / Line / KakaoTalk / Twitter / LinkedIn / WeChat / Outlook / WhatsApp / Pinterest / Telegram / Snapchat plus the generic Android WebView marker [[3]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R34-R46).
- New `pickMobileFallbackUrl()` [[1]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R66-R87) that branches on browser class and returns `{ url, reason }` with the right priority for each [[2]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R79-R85).
- Refactored all three priority call sites (async-tracking redirect resolution at L269-303 [[1]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R321-R362), regular redirect path at L394-440 [[2]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R440-R491), and interstitial fallback at L481-503 [[3]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R533-R543)) to share the helper. Path A (interstitial) and Path B (regular) now agree on priority - they were inconsistent before.
- Existing `isIOSInAppBrowser` is now exported [[1]](https://github.com/LinkForty/core/pull/23/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R12).

## Tests

`src/routes/redirect.test.ts` [[1]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5df) - 32 new unit tests covering:

- Both in-app browser detectors (true positives for each pattern, no false-positives on Safari/Chrome/Firefox) [[1]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR51-R73) [[2]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR75-R97).
- `pickMobileFallbackUrl` across iOS/Android × regular/in-app × all combinations of configured URLs [[1]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR99-R115) [[2]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR117-R129) [[3]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR131-R147) [[4]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR149-R162).
- Direct regression test for the SIT-163 scenario (iOS Safari → App Store; Gmail in-app → web fallback) [[1]](https://github.com/LinkForty/core/pull/23/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR164-R186).

All 113 core tests pass (81 existing + 32 new).
