### PR TITLE
feat(sdk): accept optional appToken on /api/sdk/v1/install

### DIFF
--- a/src/routes/sdk.ts
+++ b/src/routes/sdk.ts
@@ -52,6 +52,11 @@ export async function sdkRoutes(fastify: FastifyInstance) {
       platformVersion: z.string().optional(),
       deviceId: z.string().optional(),
       attributionWindowHours: z.number().optional(),
+      // Public app token shipped in SDK app bundles to scope organic
+      // installs to the right org in multi-tenant deployments. Used by
+      // Cloud's onSend hook (see cloud-event-hook.ts). Self-hosted
+      // single-tenant deployments simply ignore it.
+      appToken: z.string().optional(),
     });
 
     const body = schema.parse(request.body);


### PR DESCRIPTION
Adds an optional \`appToken\` field to the install endpoint's request schema. Self-hosted single-tenant deployments accept the field and ignore it - no behavior change.

Cloud uses it via an onSend hook (in linkforty/cloud, separate PR) to scope organic install events to the right workspace. Without this schema entry, Zod would strip the field before the hook could read it from \`request.body\`.

## What this is

The \`appToken\` is a public Stripe-style publishable key shipped in SDK app bundles. It:

- Only identifies which workspace owns the install
- Cannot authenticate API actions
- Cannot expose private data
- Is safe to include in mobile app bundles

## What this isn't

This PR makes **no semantic change** to the install endpoint's behavior in core. The endpoint:

- Still authenticates as None (unauthenticated)
- Still computes the same fingerprint match
- Still returns the same response

The only change is that the Zod schema now formally accepts an extra optional field. 
