### PR TITLE
docs(sdk-spec): document optional appToken for Cloud install scoping

### DIFF
--- a/SDK_SPEC.md
+++ b/SDK_SPEC.md
@@ -72,6 +72,28 @@ Matches a new app install back to the link click that drove it, using probabilis
 
 `POST /api/sdk/v1/install` -- see [endpoints reference](#api-endpoints-reference)
 
+### App token (Cloud only)
+
+The SDK should accept an optional **`appToken`** during initialization and include it in the `/api/sdk/v1/install` request body. The app token is a public, workspace-scoped identifier that lets LinkForty Cloud attribute installs to the right workspace -- including organic (unattributed) installs that wouldn't otherwise be tied to any workspace.
+
+- **Where to find it:** Cloud Dashboard → Workspace Settings → **App Token**
+- **Format:** `at_<32 hex chars>`
+- **Safety:** The token is *public* -- designed to ship inside your app bundle. It only identifies which workspace owns the install; it cannot authenticate API actions or expose private data.
+- **Self-hosted Core:** The endpoint accepts the field but ignores it. Self-hosted single-tenant deployments don't need it.
+- **Without a token:** Attributed installs (deeplink click → app open) still work via the existing fingerprint matcher. Organic installs (App Store discovery, social mentions, etc.) won't be visible in your workspace's analytics until the token is configured.
+
+Example install request body:
+
+```json
+{
+  "userAgent": "...",
+  "platform": "ios",
+  "platformVersion": "17.4",
+  "deviceId": "...",
+  "appToken": "at_a1b2c3d4e5f6...."
+}
+```
+
 ---
 
 ## 3. Direct Deep Linking
@@ -224,6 +246,7 @@ The SDK must provide access to cached attribution data from local storage withou
 | Field | Description | Default |
 |-------|-------------|---------|
 | API key | Required for link creation and Cloud features | None |
+| App token | Public workspace identifier for Cloud install scoping (format: `at_<32 hex>`). See [Section 2 → App token](#app-token-cloud-only). Self-hosted Core ignores this field. | None |
 | Debug mode | Enable verbose logging | Off |
 | Attribution window | How far back to match installs to clicks | 7 days (168 hours) |
 
@@ -278,7 +301,7 @@ All endpoints are relative to the configured base URL.
 
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| `POST` | `/api/sdk/v1/install` | None | Report install, get deferred deep link |
+| `POST` | `/api/sdk/v1/install` | None | Report install, get deferred deep link. Body accepts optional `appToken` for Cloud workspace scoping. |
 | `GET` | `/api/sdk/v1/resolve/:shortCode` | None | Resolve link without redirect |
 | `GET` | `/api/sdk/v1/resolve/:templateSlug/:shortCode` | None | Resolve template link without redirect |
 | `POST` | `/api/sdk/v1/event` | None | Track in-app events |


### PR DESCRIPTION
Companion to #24 (1.15.0 release) and the four SDK PRs.

\`SDK_SPEC.md\` is the canonical contract that contributors building new LinkForty SDKs read first. Today it doesn't mention \`appToken\` — so any new SDK (community or otherwise) would skip it and customers using that SDK with Cloud would silently lose organic-install attribution.

## What changed

- **Section 2 (Deferred Deep Linking)** — new \"App token (Cloud only)\" sub-section explaining:
  - Where to find the token (Cloud Dashboard → Workspace Settings)
  - Format (\`at_<32 hex>\`) and the public-token safety model
  - Self-hosted Core ignores the field
  - Attribution behavior with vs. without a token
  - Example install request body
- **Section 11 (Configuration)** — adds \`App token\` row to the Optional config table.
- **API Endpoints Reference** — notes \`POST /api/sdk/v1/install\` body accepts optional \`appToken\`.

The four official SDKs (RN, Expo, iOS, Android) already implement this in their open PRs.

## Out of scope

- Backend implementation — already shipped in #24 (v1.15.0). The \`appToken\` field is accepted and ignored by Core; Cloud uses it for org scoping.
- Endpoint behavior changes — none. This is doc-only.

## Test plan

- [ ] Read Section 2 → \"App token (Cloud only)\" — checks the spec is internally consistent
- [ ] Verify Optional configuration table renders and the in-page link to \`#app-token-cloud-only\` resolves
- [ ] Confirm API Endpoints Reference table reads cleanly