### PR TITLE
feat(redirect): optional click-id passthrough on web destinations

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -82,6 +82,7 @@ export async function initializeDatabase(options: DatabaseOptions = {}) {
         targeting_rules JSONB DEFAULT '{}',
         is_active BOOLEAN DEFAULT true,
         expires_at TIMESTAMP,
+        append_click_id BOOLEAN DEFAULT false,
         created_at TIMESTAMP DEFAULT NOW(),
         updated_at TIMESTAMP DEFAULT NOW()
       )
@@ -366,6 +367,24 @@ export async function initializeDatabase(options: DatabaseOptions = {}) {
           WHERE table_name='links' AND column_name='deep_link_parameters'
         ) THEN
           ALTER TABLE links ADD COLUMN deep_link_parameters JSONB DEFAULT '{}';
+        END IF;
+      END $$;
+    `);
+
+    // Click correlation id passthrough (opt-in, default off). When enabled per
+    // link, the redirect appends ?lf_click=<click id> to web/HTTPS destinations
+    // so a downstream analytics tool on the landing page can tie the landing
+    // visit back to the exact originating click. Off by default so the redirect
+    // never alters a destination's query string unless explicitly opted in.
+    // App-scheme/deep-link destinations are never appended to regardless.
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='links' AND column_name='append_click_id'
+        ) THEN
+          ALTER TABLE links ADD COLUMN append_click_id BOOLEAN DEFAULT false;
         END IF;
       END $$;
     `);

--- a/src/routes/redirect.ts
+++ b/src/routes/redirect.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { FastifyInstance } from 'fastify';
 import { db } from '../lib/database.js';
 import { getClientIp } from '../lib/client-ip.js';
@@ -248,6 +249,11 @@ export async function redirectRoutes(fastify: FastifyInstance) {
       }
     }
 
+    // Generate the click id up front (rather than letting the DB default it on
+    // insert) so the synchronous redirect below can carry it on the destination
+    // URL while the click row is still written asynchronously with the same id.
+    const clickId = randomUUID();
+
     // Track click asynchronously
     setImmediate(async () => {
       try {
@@ -272,15 +278,16 @@ export async function redirectRoutes(fastify: FastifyInstance) {
         const fpScreenWidth = query?.fp_sw ? parseInt(query.fp_sw, 10) : undefined;
         const fpScreenHeight = query?.fp_sh ? parseInt(query.fp_sh, 10) : undefined;
 
-        // Insert click event
-        const clickResult = await db.query(
+        // Insert click event with the pre-generated id (see above) so the row
+        // matches the lf_click value already placed on the redirect URL.
+        await db.query(
           `INSERT INTO click_events (
-            link_id, ip_address, user_agent, device_type, platform,
+            id, link_id, ip_address, user_agent, device_type, platform,
             country_code, country_name, region, city, latitude, longitude, timezone,
             utm_source, utm_medium, utm_campaign, referrer
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
-          RETURNING id`,
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
           [
+            clickId,
             link.id,
             ip,
             userAgent,
@@ -299,8 +306,6 @@ export async function redirectRoutes(fastify: FastifyInstance) {
             referrer,
           ]
         );
-
-        const clickId = clickResult.rows[0].id;
 
         // Store device fingerprint for deferred deep linking
         const fingerprintData: FingerprintData = {
@@ -513,6 +518,20 @@ export async function redirectRoutes(fastify: FastifyInstance) {
         } catch (error) {
           // If URL parsing fails, continue without deep link parameters
           console.error('Failed to add deep link parameters:', error);
+        }
+      }
+
+      // When opted in per link (append_click_id), append the originating click id
+      // so a downstream analytics tool on the landing page can correlate the
+      // landing visit to this exact click. Opt-in (default off), web/HTTPS only —
+      // an absent/false flag (incl. stale cache) leaves the destination untouched.
+      if (link.append_click_id === true) {
+        try {
+          const url = new URL(finalUrl);
+          url.searchParams.set('lf_click', clickId);
+          finalUrl = url.toString();
+        } catch {
+          // Non-absolute / unparseable URL — skip the correlation param.
         }
       }
     } else {


### PR DESCRIPTION
## Summary

Adds an **opt-in (default off)** per-link capability to append `?lf_click=<click id>` to HTTP(S) redirect destinations, so a downstream tool can correlate a landing visit back to the exact click that sent it (industry-standard click-id passthrough, à la `gclid`/`fbclid`).

## Why / Usage

Every click is already recorded in `click_events`, but that click id never leaves the server - so a destination site can't tie a later conversion back to the specific click that drove it. This adds the standard click-identifier passthrough (the same pattern as `gclid`, `fbclid`, `msclkid`): when enabled, the redirect forwards the click's id on the destination URL as `lf_click`, so first-party analytics or your own backend can correlate the landing visit - and any downstream conversion - to that exact row in `click_events`. This makes per-click attribution possible without any extra server round-trip.

**Example.** A link points to `https://shop.example/landing`. With `append_click_id` enabled, the visitor lands on `https://shop.example/landing?lf_click=<uuid>`; the page reads the param and stores it alongside the resulting signup/purchase, so conversions can be attributed to individual clicks. It's opt-in and default-off, so destination URLs are left untouched unless you turn it on per link.

## Details

- New `links.append_click_id` column, **default `false`** - the redirect never alters a destination's query string unless a link explicitly opts in. [[CREATE TABLE]](https://github.com/LinkForty/core/pull/30/files#diff-ab64e4f563fa8916b87745237336a7ff7aadf0b5985fe18ba6776f08c8d4ee5bR85) [[idempotent ALTER]](https://github.com/LinkForty/core/pull/30/files#diff-ab64e4f563fa8916b87745237336a7ff7aadf0b5985fe18ba6776f08c8d4ee5bR374-R390)
- The click id is now generated up front (rather than defaulted by the DB on insert), so the synchronous 302 carries the **same id** the asynchronous click row is written with. [[generate up front]](https://github.com/LinkForty/core/pull/30/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R252-R255) [[insert with id]](https://github.com/LinkForty/core/pull/30/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R285-R290)
- **Web/HTTPS destinations only.** App-scheme / deep-link destinations are never modified. [[passthrough]](https://github.com/LinkForty/core/pull/30/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R524-R536)
- Stale-cache safe: an absent/false flag leaves the destination untouched. [[guard]](https://github.com/LinkForty/core/pull/30/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R528)

## Tests

`npm test` - 132 passing (incl. 32 redirect tests).
