### PR TITLE
feat(redirect): serve a friendly 410 page for expired links

### DIFF
--- a/src/routes/redirect.test.ts
+++ b/src/routes/redirect.test.ts
@@ -3,6 +3,8 @@ import {
   isIOSInAppBrowser,
   isAndroidInAppBrowser,
   pickMobileFallbackUrl,
+  isLinkExpired,
+  generateExpiredLinkHTML,
 } from './redirect.js';
 
 // Real-world UA strings (truncated where helpful) for use across test cases.
@@ -182,5 +184,42 @@ describe('pickMobileFallbackUrl — reporter scenario regression test', () => {
   it('Android Facebook in-app → web fallback (preserves UL second-chance)', () => {
     const r = pickMobileFallbackUrl('android', UA.androidFacebook, URLS.iosStore, URLS.androidStore, URLS.webFallback);
     expect(r?.url).toBe(URLS.webFallback);
+  });
+});
+
+describe('isLinkExpired', () => {
+  const now = new Date('2026-07-07T12:00:00Z');
+
+  it('null/undefined expires_at never expires', () => {
+    expect(isLinkExpired(null, now)).toBe(false);
+    expect(isLinkExpired(undefined, now)).toBe(false);
+  });
+
+  it('future timestamp is not expired', () => {
+    expect(isLinkExpired('2026-07-08T12:00:00Z', now)).toBe(false);
+    expect(isLinkExpired(new Date('2027-01-01T00:00:00Z'), now)).toBe(false);
+  });
+
+  it('past timestamp is expired', () => {
+    expect(isLinkExpired('2026-07-07T11:59:59Z', now)).toBe(true);
+    expect(isLinkExpired(new Date('2020-01-01T00:00:00Z'), now)).toBe(true);
+  });
+
+  it('exact expiry moment counts as expired', () => {
+    expect(isLinkExpired('2026-07-07T12:00:00Z', now)).toBe(true);
+  });
+
+  it('unparseable timestamp fails open (not expired)', () => {
+    expect(isLinkExpired('not-a-date', now)).toBe(false);
+  });
+});
+
+describe('generateExpiredLinkHTML', () => {
+  it('is a complete, noindexed HTML page saying the link expired', () => {
+    const html = generateExpiredLinkHTML();
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('This link has expired');
+    expect(html).toContain('noindex');
+    expect(html).toContain('</html>');
   });
 });

--- a/src/routes/redirect.ts
+++ b/src/routes/redirect.ts
@@ -136,6 +136,52 @@ function generateInterstitialHTML(schemeUrl: string, fallbackUrl: string, title?
 </body></html>`;
 }
 
+/**
+ * Whether a link's expiration timestamp has passed. Links without expires_at
+ * never expire. An unparseable timestamp is treated as not expired (fail open)
+ * so a malformed value can't take a live link down.
+ */
+export function isLinkExpired(expiresAt: string | Date | null | undefined, now: Date = new Date()): boolean {
+  if (!expiresAt) return false;
+  const t = new Date(expiresAt).getTime();
+  return Number.isFinite(t) && t <= now.getTime();
+}
+
+/**
+ * Friendly page served (with HTTP 410 Gone) when someone opens a link past its
+ * expiration date. Deliberately unbranded: core is white-label and the page is
+ * served on customers' own short-link domains.
+ */
+export function generateExpiredLinkHTML(): string {
+  return `<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Link expired</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; background: #f9fafb; color: #111827; text-align: center; }
+  .container { padding: 2rem; max-width: 26rem; }
+  .clock { width: 48px; height: 48px; margin: 0 auto 1.5rem; color: #9ca3af; }
+  h1 { font-size: 1.25rem; font-weight: 600; margin: 0 0 0.5rem; }
+  p { font-size: 0.875rem; color: #6b7280; margin: 0; line-height: 1.5; }
+  .powered { position: fixed; bottom: 1.25rem; left: 0; right: 0; font-size: 0.75rem; color: #9ca3af; }
+  .powered a { color: #6b7280; text-decoration: none; font-weight: 500; }
+  .powered a:hover { text-decoration: underline; }
+</style>
+</head><body>
+<div class="container">
+  <svg class="clock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="9"></circle>
+    <path d="M12 7v5l3 2"></path>
+  </svg>
+  <h1>This link has expired</h1>
+  <p>The link you followed is no longer active. If you were expecting to find something here, ask whoever shared it for an up-to-date link.</p>
+</div>
+<div class="powered">Powered by <a href="https://linkforty.com" rel="noopener">LinkForty</a></div>
+</body></html>`;
+}
+
 export async function redirectRoutes(fastify: FastifyInstance) {
   // Helper function to handle the actual redirect logic
   async function handleRedirect(request: any, reply: any, shortCode: string, templateSlug?: string) {
@@ -188,6 +234,22 @@ export async function redirectRoutes(fastify: FastifyInstance) {
       const result = await db.query(query, params);
 
       if (result.rows.length === 0) {
+        // Distinguish "expired" from "never existed": an expired link keeps its
+        // expires_at even after the hourly expiration job flips is_active off,
+        // so this lookup stays accurate long after expiry.
+        const expiredCheck = templateSlug
+          ? await db.query(
+              `SELECT 1 FROM links l JOIN link_templates t ON l.template_id = t.id
+               WHERE l.short_code = $1 AND t.slug = $2 AND l.expires_at IS NOT NULL AND l.expires_at <= NOW()`,
+              [shortCode, templateSlug]
+            )
+          : await db.query(
+              'SELECT 1 FROM links WHERE short_code = $1 AND expires_at IS NOT NULL AND expires_at <= NOW()',
+              [shortCode]
+            );
+        if (expiredCheck.rows.length > 0) {
+          return reply.status(410).type('text/html').send(generateExpiredLinkHTML());
+        }
         return reply.status(404).send({ error: 'Link not found' });
       }
 
@@ -204,6 +266,12 @@ export async function redirectRoutes(fastify: FastifyInstance) {
     }
 
     const link = JSON.parse(linkData);
+
+    // Enforce expiry on cache hits too — a link cached shortly before expiring
+    // would otherwise keep redirecting for up to the cache TTL (5 minutes).
+    if (isLinkExpired(link.expires_at)) {
+      return reply.status(410).type('text/html').send(generateExpiredLinkHTML());
+    }
 
     // Check targeting rules BEFORE redirecting
     if (link.targeting_rules) {


### PR DESCRIPTION
## Summary

- **Expired links now show a proper page.** Opening a short link past its `expires_at` returns **HTTP 410 Gone** with a lightweight HTML page — clock icon, "This link has expired", one line of guidance, and a small "Powered by LinkForty" footer. Previously expired links returned the same bare `404 {"error":"Link not found"}` as short codes that never existed. [[1]](https://github.com/LinkForty/core/pull/34/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R150-R183)
- **Expired vs. never-existed is now distinguished.** When the active-link lookup misses, a secondary query checks for a link with that short code whose `expires_at` has passed (both the template-slug and legacy URL forms). Since expired links keep their `expires_at` even after a housekeeping job deactivates them, the 410 page keeps serving indefinitely. Unknown short codes still 404. [[1]](https://github.com/LinkForty/core/pull/34/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R237-R252)
- **Expiry is now enforced on Redis cache hits.** A link cached shortly before expiring used to keep redirecting for up to the 5-minute cache TTL; the redirect now re-checks `expires_at` after a cache read, so links stop at the exact expiration moment. [[1]](https://github.com/LinkForty/core/pull/34/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R270-R274)
- The page carries `noindex` so expired links drop out of search engines, and it's served on whatever domain the short link uses. [[1]](https://github.com/LinkForty/core/pull/34/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R160)
- New exported helpers `isLinkExpired()` (null/invalid timestamps fail open) and `generateExpiredLinkHTML()`, both unit-tested. [[1]](https://github.com/LinkForty/core/pull/34/files#diff-45fd92b1924f389983abb018838ab706b5aa3333b0d0c2e3a832f7158a9d7d02R139-R148) [[2]](https://github.com/LinkForty/core/pull/34/files#diff-61a18a0e28669baf8d006c7b1d94d5c12d43dd17ffeb4dfe1812431600bbe5dfR190-R225)

## Test plan

- `npm test` — 145 tests pass, including new coverage for `isLinkExpired` (no expiry, future, past, exact-moment, unparseable) and the page content.
- `npm run build` clean.
- Manual: create a link with `expiresAt` in the near future, click it before expiry (redirect works), after expiry (410 page), and confirm an unknown short code still returns 404.
