### PR TITLE
ci: seed the CLA signature file so the action can read it

### DIFF
--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
## Summary

Follow-up to #39. That PR fixed the branch the CLA action reads from, but the `cla` check still fails on every PR with the same error:

```
##[error]Could not retrieve repository contents. Status: 404
```

The config is now demonstrably correct — the run on #37 reports:

```
branch: main
path-to-signatures: signatures/cla.json
```

and still 404s, because **that file has never existed in this repo**.

## Why the action can't create it itself

It's supposed to. `setupClaCheck.ts` handles a missing signature file by bootstrapping one — except the check is wrong:

```ts
try {
  result = await getFileContent()
} catch (error) {
  if (error.status === "404") {                        // string
    return createClaFileAndPRComment(committers, committerMap)
  } else {
    throw new Error(
      `Could not retrieve repository contents. Status: ${error.status || 'unknown'}`
    )
  }
}
```

Octokit sets `error.status` as a **number**, so `404 === "404"` is `false`, the bootstrap branch is unreachable, and every missing file becomes the thrown error we've been seeing. `cla-assistant/github-action@v2.4.0` can only work against a signature file that already exists — so it has to be committed by hand.

## The change

One file, containing exactly what the action would have written:

```json
{
  "signedContributors": []
}
```

Indented with **two** spaces rather than the three its create path uses. The action is inconsistent with itself — `createClaFileAndPRComment` serialises with `JSON.stringify(content, null, 3)` while `updateFile` re-serialises with `null, 2`. Since every real signature goes through the update path, matching that keeps the first signature's diff to a single line instead of reformatting the whole file.

## Verification

| Check | Result |
|---|---|
| Parses as JSON, `signedContributors` is an array | Yes |
| Covered by `.gitignore`? | No — confirmed with `git check-ignore`, so it actually lands |
| `main` branch protection (action must commit here) | None |
| Path matches the workflow's `path-to-signatures` | `signatures/cla.json` — exact |

## Scope and impact

Both halves were needed, and neither alone was sufficient: without #39 the action looked for a `master` ref that doesn't exist here; without this file it 404s on a path that doesn't exist.

Worth stating plainly — **this was never a compliance gap.** `main` is unprotected so the `cla` check gates nothing, and `license/cla` (the cla-assistant.io status check) has been passing the whole time. Only the Action half was broken.

`ci:` is not a releasable type under `.releaserc.json`, so merging this publishes nothing.

## After merge

The next PR event will exercise it for real. If the check goes green there, the action has read the file and taken over; the first outside contributor to sign will append to it.
