### PR TITLE
fix(analytics): record link-configured UTMs on click events (SIT-382)

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -5,6 +5,7 @@ import {
   buildRedirectUrl,
   detectDevice,
   getLocationFromIP,
+  resolveClickUtms,
 } from './utils';
 
 describe('generateShortCode', () => {
@@ -183,5 +184,81 @@ describe('getLocationFromIP', () => {
       // Has a mapped name
       expect(typeof result.countryName).toBe('string');
     }
+  });
+});
+
+describe('resolveClickUtms', () => {
+  const CONFIG = { source: 'youtube', medium: 'social', campaign: 'time_video' };
+
+  it('uses inbound query-string values when the link has no configured UTMs', () => {
+    expect(resolveClickUtms({ utm_source: 'fb', utm_medium: 'cpc', utm_campaign: 'launch' }, undefined))
+      .toEqual({ utmSource: 'fb', utmMedium: 'cpc', utmCampaign: 'launch' });
+  });
+
+  it('falls back to the link configuration when nothing is inbound', () => {
+    expect(resolveClickUtms({}, CONFIG))
+      .toEqual({ utmSource: 'youtube', utmMedium: 'social', utmCampaign: 'time_video' });
+  });
+
+  it('lets inbound win over configuration on conflict', () => {
+    // An ad platform appending a per-ad campaign id must not be overwritten by
+    // the link's static label.
+    expect(resolveClickUtms({ utm_source: 'an', utm_campaign: '120252316702960562' }, { source: 'test', campaign: 'test' }))
+      .toMatchObject({ utmSource: 'an', utmCampaign: '120252316702960562' });
+  });
+
+  it('mixes the two sources per key rather than all-or-nothing', () => {
+    expect(resolveClickUtms({ utm_source: 'fb' }, CONFIG))
+      .toEqual({ utmSource: 'fb', utmMedium: 'social', utmCampaign: 'time_video' });
+  });
+
+  it('treats an empty inbound value as absent and falls through to configuration', () => {
+    expect(resolveClickUtms({ utm_source: '' }, CONFIG).utmSource).toBe('youtube');
+  });
+
+  it('treats a whitespace-only inbound value as absent', () => {
+    expect(resolveClickUtms({ utm_source: '   ' }, CONFIG).utmSource).toBe('youtube');
+  });
+
+  it('never returns an empty string when configuration holds a blank', () => {
+    // Real production shape: a link saved with campaign set to ''.
+    const result = resolveClickUtms({}, { source: 'clevertap', medium: 'email', campaign: '' });
+    expect(result.utmCampaign).toBeUndefined();
+    expect(result.utmSource).toBe('clevertap');
+  });
+
+  it('trims values so " ig" and "ig" do not split into two library entries', () => {
+    expect(resolveClickUtms({ utm_source: '  ig  ' }, undefined).utmSource).toBe('ig');
+    expect(resolveClickUtms({}, { source: ' youtube ' }).utmSource).toBe('youtube');
+  });
+
+  it.each([
+    ['null', null],
+    ['an array', [] as unknown as Record<string, string>],
+    ['a JSON string', '{"source":"x"}' as unknown as Record<string, string>],
+    ['undefined', undefined],
+  ])('treats %s utm_parameters as absent', (_label, configured) => {
+    expect(resolveClickUtms({ utm_source: 'fb' }, configured))
+      .toEqual({ utmSource: 'fb', utmMedium: undefined, utmCampaign: undefined });
+  });
+
+  it('ignores a repeated query parameter arriving as an array', () => {
+    const query = { utm_source: ['a', 'b'] } as unknown as Record<string, string | undefined>;
+    expect(resolveClickUtms(query, CONFIG).utmSource).toBe('youtube');
+  });
+
+  it('returns all-undefined when neither source supplies anything', () => {
+    expect(resolveClickUtms({}, {}))
+      .toEqual({ utmSource: undefined, utmMedium: undefined, utmCampaign: undefined });
+    expect(resolveClickUtms(undefined, undefined))
+      .toEqual({ utmSource: undefined, utmMedium: undefined, utmCampaign: undefined });
+  });
+
+  it('ignores content and term, which have no click_events columns', () => {
+    const result = resolveClickUtms({ utm_content: 'cta', utm_term: 'kw' } as Record<string, string | undefined>, {
+      source: 'frontend', content: 'aasa_footer_cta', term: 'kw',
+    });
+    expect(Object.keys(result).sort()).toEqual(['utmCampaign', 'utmMedium', 'utmSource']);
+    expect(result.utmSource).toBe('frontend');
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -149,6 +149,63 @@ export function buildRedirectUrl(
   }
 }
 
+/** UTM keys that have a matching column on `click_events`. */
+const CLICK_UTM_KEYS = ['source', 'medium', 'campaign'] as const;
+
+type ClickUtmKey = (typeof CLICK_UTM_KEYS)[number];
+
+/** Trimmed string, or undefined for blanks and non-strings (e.g. a repeated query param arriving as an array). */
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+/**
+ * Resolve the UTM values to persist on a click row.
+ *
+ * Two sources can supply a UTM: the inbound query string on the short-link
+ * request, and the UTMs configured on the link itself (`links.utm_parameters`,
+ * which `buildRedirectUrl` appends to the *destination* URL). Historically only
+ * the inbound query string was recorded, so a link whose UTMs live in link
+ * settings wrote NULLs and never appeared in campaign analytics — the value
+ * reached the landing page but never the click row.
+ *
+ * Inbound wins, per key. A value a sharer put on the short URL is more specific
+ * than the link's static configuration — an ad platform appending a per-ad
+ * campaign id, say — and letting configuration overwrite it would destroy the
+ * finer signal. Keys resolve independently, so a link that configures only
+ * `source` still records an inbound `campaign`.
+ *
+ * Blank and whitespace-only values on either side are treated as absent and
+ * resolve to `undefined`, never `''`: campaign analytics filters on
+ * `IS NOT NULL AND <> ''` but groups on the raw value, so an empty string would
+ * surface as a blank-labelled row. Values are stored trimmed so that ` ig` and
+ * `ig` don't split into two entries in the UTM library.
+ *
+ * `content` and `term` are ignored — `click_events` has no column for them.
+ */
+export function resolveClickUtms(
+  query: Record<string, string | undefined> | undefined,
+  linkUtmParameters: Record<string, string> | null | undefined
+): { utmSource?: string; utmMedium?: string; utmCampaign?: string } {
+  // `utm_parameters` is raw JSONB — guard against null, arrays and scalars
+  // before indexing into it.
+  const configured =
+    linkUtmParameters && typeof linkUtmParameters === 'object' && !Array.isArray(linkUtmParameters)
+      ? linkUtmParameters
+      : undefined;
+
+  const pick = (key: ClickUtmKey): string | undefined =>
+    nonEmptyString(query?.[`utm_${key}`]) ?? nonEmptyString(configured?.[key]);
+
+  return {
+    utmSource: pick('source'),
+    utmMedium: pick('medium'),
+    utmCampaign: pick('campaign'),
+  };
+}
+
 /**
  * Detect the device platform from a User-Agent string.
  *

--- a/src/routes/redirect.ts
+++ b/src/routes/redirect.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { FastifyInstance } from 'fastify';
 import { db } from '../lib/database.js';
 import { getClientIp } from '../lib/client-ip.js';
-import { parseUserAgent, getLocationFromIP, buildRedirectUrl, detectDevice } from '../lib/utils.js';
+import { parseUserAgent, getLocationFromIP, buildRedirectUrl, detectDevice, resolveClickUtms } from '../lib/utils.js';
 import { storeFingerprintForClick, type FingerprintData } from '../lib/fingerprint.js';
 import { emitClickEvent } from '../lib/event-emitter.js';
 import { classifyBot, edgeBotSignal } from '../lib/bot-detection.js';
@@ -362,11 +362,12 @@ export async function redirectRoutes(
           edgeBotSignal(request.headers['x-lf-bot'])
         );
 
-        // Extract UTM parameters from query string
+        // Resolve the UTMs recorded on the click row. Inbound query-string
+        // values win per key; the link's configured UTMs (the same ones
+        // buildRedirectUrl puts on the destination) fill anything left blank,
+        // so link-tagged campaigns show up in analytics instead of NULLs.
         const query = request.query as Record<string, string | undefined>;
-        const utmSource = query?.utm_source;
-        const utmMedium = query?.utm_medium;
-        const utmCampaign = query?.utm_campaign;
+        const { utmSource, utmMedium, utmCampaign } = resolveClickUtms(query, link.utm_parameters);
 
         // Extract fingerprint data from query params (sent by SDK/client)
         const fpTimezone = query?.fp_tz || timezone || undefined;


### PR DESCRIPTION
[SIT-382](https://linear.app/sitetransition/issue/SIT-382/record-link-configured-utms-on-click-events-so-the-campaigns-tab)

## The problem

`click_events.utm_*` was only ever populated from the **inbound query string** on the short-link request. UTMs configured in link settings are appended to the **destination URL** by `buildRedirectUrl`, so they reached the landing page but never the click row. Every campaign analytics surface read `NULL` for a link-tagged click.

Verified against production: a pro-tier workspace had **0 of 3,111** clicks carrying a campaign, all-time, while 3,758 of its web events carried one.

## The change

`resolveClickUtms()` resolves `source` / `medium` / `campaign` independently — inbound query-string value wins, link configuration fills anything left blank.

**Inbound takes precedence** because a value a sharer put on the short URL is more specific than static link configuration. Production has one workspace running Meta ads into a link whose configured campaign is the placeholder `test`; letting configuration win would replace their real per-ad campaign IDs with `test`.

Blank and whitespace-only values resolve to `undefined` rather than `''`, since campaign analytics filters on `IS NOT NULL AND <> ''` but groups on the raw value. Values are stored trimmed so `" ig"` and `"ig"` don't split into two UTM library entries. A repeated query parameter arriving as an array falls through to configuration instead of being handed to a `VARCHAR` column.

## Blast radius

Strictly additive — no backfill, so no historical number changes. The write is inside `setImmediate` after the response, so redirect latency is untouched.

`redirect.ts` changes are two hunks (the import and the resolution block). Nothing within 90 lines of `buildRedirectUrl` (467, 606) or `lf_click` (629) — **the destination URL and click-id paths are provably untouched**.

## Verification

- `npx tsc --noEmit` clean
- **213 tests pass** across 14 files, including `redirect.safety.test.ts`
- `npm run build` clean
- 13 new cases in `utils.test.ts` covering precedence, per-key mixing, blanks, whitespace, non-object `utm_parameters`, and array query params

## Note for whoever deploys

Campaign data will appear to **start from zero on deploy day** for workspaces that tag links. It's new data, not a spike — worth a changelog line so nobody trends across the discontinuity.