### PR TITLE
fix(attribution): match deferred installs against their click

### DIFF
--- a/src/lib/fingerprint.test.ts
+++ b/src/lib/fingerprint.test.ts
@@ -209,6 +209,115 @@ describe('calculateConfidenceScore — shared-IP filter', () => {
   });
 });
 
+describe('calculateConfidenceScore - deferred install (SDK vs browser)', () => {
+  // A real deferred install: the click carries a Safari user agent, the install
+  // carries the string FingerprintCollector builds. Same device, same wifi.
+  const safariClick = {
+    ipAddress: '103.28.14.77',
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+    timezone: 'Asia/Jakarta',
+    language: 'en-US',
+    screenWidth: 393, // CSS pixels
+    screenHeight: 852,
+    platform: 'ios', // detectDevice()
+    platformVersion: '17.5',
+  };
+
+  const sdkInstall = {
+    ipAddress: '103.28.14.77',
+    userAgent: 'MNC Play/1.0.0 iOS/17.5', // generateUserAgent()
+    timezone: 'Asia/Jakarta',
+    language: 'en_US', // Locale.current.identifier
+    screenWidth: 1179, // native pixels (bounds * scale)
+    screenHeight: 2556,
+    platform: 'iOS',
+    platformVersion: '17.5',
+  };
+
+  it('attributes an iOS install that matches its click', () => {
+    const { score, matchedFactors } = fingerprint.calculateConfidenceScore(
+      sdkInstall,
+      safariClick
+    );
+
+    expect(score).toBeGreaterThanOrEqual(fingerprint.CONFIDENCE_THRESHOLD);
+    expect(matchedFactors).toEqual(
+      expect.arrayContaining(['ip', 'platform', 'platform_version', 'timezone', 'language'])
+    );
+  });
+
+  it('matches native-pixel screens against CSS-pixel screens', () => {
+    const { matchedFactors } = fingerprint.calculateConfidenceScore(sdkInstall, safariClick);
+    expect(matchedFactors).toContain('screen');
+  });
+
+  it('attributes an Android install that matches its click', () => {
+    const chromeClick = {
+      ...safariClick,
+      userAgent:
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+      platform: 'android',
+      platformVersion: '14',
+      screenWidth: 412,
+      screenHeight: 915,
+    };
+    const androidInstall = {
+      ...sdkInstall,
+      userAgent: 'MNC Play/1.0.0 Android/14',
+      platform: 'Android',
+      platformVersion: '14',
+      screenWidth: 1080,
+      screenHeight: 2400,
+    };
+
+    const { score } = fingerprint.calculateConfidenceScore(androidInstall, chromeClick);
+    expect(score).toBeGreaterThanOrEqual(fingerprint.CONFIDENCE_THRESHOLD);
+  });
+
+  it('still attributes when the click carries no screen dimensions', () => {
+    const noScreen = { ...safariClick, screenWidth: undefined, screenHeight: undefined };
+
+    const { score } = fingerprint.calculateConfidenceScore(sdkInstall, noScreen);
+    expect(score).toBeGreaterThanOrEqual(fingerprint.CONFIDENCE_THRESHOLD);
+  });
+
+  it('disqualifies a click from a different platform', () => {
+    const androidClick = {
+      ...safariClick,
+      userAgent:
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+      platform: 'android',
+      platformVersion: '14',
+    };
+
+    const { score, matchedFactors } = fingerprint.calculateConfidenceScore(
+      sdkInstall,
+      androidClick
+    );
+
+    expect(score).toBe(0);
+    expect(matchedFactors).toEqual([]);
+  });
+
+  it('does not attribute an install seen on a different network', () => {
+    const { score } = fingerprint.calculateConfidenceScore(
+      { ...sdkInstall, ipAddress: '114.10.9.3' },
+      safariClick
+    );
+
+    expect(score).toBeLessThan(fingerprint.CONFIDENCE_THRESHOLD);
+  });
+
+  it('still requires exact screen equality between two browsers', () => {
+    const a = { ...safariClick, screenWidth: 800, screenHeight: 600 };
+    const b = { ...safariClick, screenWidth: 1200, screenHeight: 900 };
+
+    const { matchedFactors } = fingerprint.calculateConfidenceScore(a, b);
+    expect(matchedFactors).not.toContain('screen');
+  });
+});
+
 describe('matchInstallToClick', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/src/lib/fingerprint.ts
+++ b/src/lib/fingerprint.ts
@@ -40,6 +40,16 @@ const FINGERPRINT_WEIGHTS = {
 };
 
 /**
+ * How the USER_AGENT weight is split when an SDK fingerprint is compared against
+ * a browser fingerprint. The two never produce comparable user agent strings, so
+ * platform and OS version stand in for them. Sums to USER_AGENT.
+ */
+const CROSS_CONTEXT_WEIGHTS = {
+  PLATFORM: 20,
+  PLATFORM_VERSION: 10,
+};
+
+/**
  * Default attribution window in hours (7 days)
  */
 export const DEFAULT_ATTRIBUTION_WINDOW_HOURS = 168;
@@ -177,6 +187,95 @@ function normalizeUserAgent(ua: string): string {
 }
 
 /**
+ * Matches the user agent the mobile SDKs generate, e.g. "MyApp/1.2.0 iOS/17.5"
+ * or "MyApp/1.2.0 Android/14". Browser user agents never end this way.
+ */
+const SDK_USER_AGENT = /\s(iOS|Android)\/([0-9][0-9._]*)\s*$/i;
+
+/**
+ * Parse an SDK-generated user agent. Returns null for browser user agents.
+ */
+function parseSdkUserAgent(ua: string): { platform: string; version: string } | null {
+  const match = ua.match(SDK_USER_AGENT);
+  if (!match) return null;
+
+  return { platform: match[1].toLowerCase(), version: match[2] };
+}
+
+/**
+ * Reduce the spellings of a platform used by the SDKs, the redirect handler and
+ * the UA parser to a single token.
+ */
+function normalizePlatform(value: string): string {
+  const platform = value.toLowerCase();
+
+  if (/iphone|ipad|ipod|^ios$/.test(platform)) return 'ios';
+  if (platform.includes('android')) return 'android';
+  if (platform.includes('macintosh') || platform.includes('mac os')) return 'macos';
+  if (platform.includes('windows')) return 'windows';
+
+  return platform;
+}
+
+/**
+ * Best-effort platform for a fingerprint: the stored platform if it names one,
+ * otherwise whatever the user agent reveals.
+ */
+function platformOf(fingerprint: FingerprintData): string {
+  const stored = normalizePlatform(fingerprint.platform || '');
+  if (stored && stored !== 'web' && stored !== 'unknown') {
+    return stored;
+  }
+
+  const match = (fingerprint.userAgent || '').match(
+    /(iPhone|iPad|iPod|Android|Windows|Macintosh|Linux)/i
+  );
+
+  return match ? normalizePlatform(match[1]) : '';
+}
+
+/**
+ * Major version only. Safari reports the OS version less precisely than
+ * UIDevice.systemVersion does, so comparing point releases produces false misses.
+ */
+function majorVersion(value?: string): string {
+  return (value || '').split(/[._]/)[0] || '';
+}
+
+/**
+ * Whether two screen sizes describe the same display.
+ *
+ * Browsers report CSS pixels while the SDKs report native pixels, so across
+ * those two contexts the dimensions differ by the device pixel ratio. The ratio
+ * applies equally to both axes, which is what distinguishes a scaled match from
+ * two genuinely different screens.
+ */
+function screensMatch(
+  fingerprint1: FingerprintData,
+  fingerprint2: FingerprintData,
+  crossContext: boolean
+): boolean {
+  const width1 = fingerprint1.screenWidth!;
+  const height1 = fingerprint1.screenHeight!;
+  const width2 = fingerprint2.screenWidth!;
+  const height2 = fingerprint2.screenHeight!;
+
+  if (width1 === width2 && height1 === height2) {
+    return true;
+  }
+
+  if (!crossContext) {
+    return false;
+  }
+
+  const widthRatio = width1 > width2 ? width1 / width2 : width2 / width1;
+  const heightRatio = height1 > height2 ? height1 / height2 : height2 / height1;
+
+  // Device pixel ratios run from 1x to 4x.
+  return widthRatio <= 4 && Math.abs(widthRatio - heightRatio) < 0.02;
+}
+
+/**
  * Calculate confidence score by comparing two fingerprints
  * Returns a score from 0-100 based on matched components
  */
@@ -205,8 +304,39 @@ export function calculateConfidenceScore(
     }
   }
 
-  // Compare user agents (normalized to platform + browser)
-  if (fingerprint1.userAgent && fingerprint2.userAgent) {
+  // Compare user agents. A deferred install pairs an SDK user agent with the
+  // browser user agent captured at click time, and those two can never be equal
+  // — the SDK string carries neither a browser nor a platform token. Whenever
+  // one side comes from an SDK, compare platform and OS version instead, which
+  // both sides do report.
+  const sdk1 = parseSdkUserAgent(fingerprint1.userAgent || '');
+  const sdk2 = parseSdkUserAgent(fingerprint2.userAgent || '');
+  const crossContext = Boolean(sdk1) !== Boolean(sdk2);
+
+  if (sdk1 || sdk2) {
+    const platform1 = sdk1 ? sdk1.platform : platformOf(fingerprint1);
+    const platform2 = sdk2 ? sdk2.platform : platformOf(fingerprint2);
+
+    // A device cannot have clicked the link from a different operating system,
+    // so a known mismatch disqualifies the candidate outright rather than just
+    // scoring zero — the remaining signals are all shared-network coincidences.
+    if (platform1 && platform2 && platform1 !== platform2) {
+      return { score: 0, matchedFactors: [] };
+    }
+
+    if (platform1 && platform1 === platform2) {
+      score += CROSS_CONTEXT_WEIGHTS.PLATFORM;
+      matchedFactors.push('platform');
+
+      const version1 = majorVersion(sdk1 ? sdk1.version : fingerprint1.platformVersion);
+      const version2 = majorVersion(sdk2 ? sdk2.version : fingerprint2.platformVersion);
+
+      if (version1 && version1 === version2) {
+        score += CROSS_CONTEXT_WEIGHTS.PLATFORM_VERSION;
+        matchedFactors.push('platform_version');
+      }
+    }
+  } else if (fingerprint1.userAgent && fingerprint2.userAgent) {
     const ua1 = normalizeUserAgent(fingerprint1.userAgent);
     const ua2 = normalizeUserAgent(fingerprint2.userAgent);
 
@@ -243,10 +373,7 @@ export function calculateConfidenceScore(
     fingerprint2.screenWidth &&
     fingerprint2.screenHeight
   ) {
-    if (
-      fingerprint1.screenWidth === fingerprint2.screenWidth &&
-      fingerprint1.screenHeight === fingerprint2.screenHeight
-    ) {
+    if (screensMatch(fingerprint1, fingerprint2, crossContext)) {
       score += FINGERPRINT_WEIGHTS.SCREEN_RESOLUTION;
       matchedFactors.push('screen');
     }


### PR DESCRIPTION
Deferred attribution was inconsistent on iOS or Android.

## Cause

`calculateConfidenceScore` compares five signals worth 100 points and attributes at ≥70. Two of them are captured differently by the SDKs than by the web click they get compared against, so neither would match:

| Signal | Click side | Install side (SDK) | Result |
| --- | --- | --- | --- |
| User agent (30) | `…(iPhone; CPU iPhone OS 17_5…) Safari/604.1` → `iphone\|safari` | `MyApp/1.0.0 iOS/17.5` → `\|` | never equal |
| Screen (10) | `393×852` (CSS px) | `1179×2556` (native px) | never equal |

`normalizeUserAgent` extracts a platform token (`iPhone|iPad|Android|…`) and a browser token. The SDK string built by `FingerprintCollector.generateUserAgent()` contains neither — `iOS` is not in the platform pattern — so it always reduced to `"|"`.

That capped every mobile install at **40 (ip) + 10 (timezone) + 10 (language) = 60**, permanently below the threshold. Android hit the same ceiling via `"android|"` vs `"android|chrome"`.

The unit tests missed it because they compare a browser UA against another browser UA on both sides, which never happens in the real deferred flow — the install side always comes from an SDK.

## Fix

When either side of a comparison comes from an SDK user agent:

- Compare **platform** and **OS major version** instead of the raw user agent, splitting the same 30 points 20/10 so the weights still total 100. Both sides already record these; they were simply never scored.
- A **known platform mismatch disqualifies** the candidate outright rather than scoring zero. A device cannot have clicked from a different OS, and without this an iOS install could still reach exactly 70 against an Android click on the same subnet via ip + timezone + language + a coincidental screen ratio.
- Compare screens **by proportion**, since the two contexts differ by the device pixel ratio. The ratio must hold on both axes, which is what separates a scaled match from two different screens.

Major version only, because Safari reports the OS version less precisely than `UIDevice.systemVersion` and comparing point releases reintroduces false misses.

**Browser-to-browser matching is unchanged** — same weights, same exact-equality screen comparison. All pre-existing tests pass untouched.

## Results

Scores from the real function, same device and network, click then install:

| Scenario | Before | After |
| --- | --- | --- |
| Typical TestFlight install | 60 organic | **100 attributed** |
| Click sent no `fp_sw`/`fp_sh` | 60 organic | **90 attributed** |
| iPad, 2x scale | 60 organic | **100 attributed** |
| Install on cellular, click on wifi | 60 organic | 60 organic |
| Android click vs iOS install | 60 organic | **0 disqualified** |

The last two are the guardrails: a genuinely unrelated install stays organic, and a cross-platform candidate is now rejected outright rather than squeaking over the line.

## Testing

7 new cases covering the deferred flow the suite never exercised, including both guardrails. Full suite: 220 passed, `tsc --noEmit` clean.

## Note

One adjacent case is left alone deliberately: in **browser-to-browser** matching, two different platforms can still reach 70 on ip + timezone + language + screen. That is pre-existing behaviour on a path this bug does not affect, so it is not changed here.