### PR TITLE
feat(schema): add click_events.link_params (SIT-410)

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -166,7 +166,8 @@ export async function initializeDatabase(options: DatabaseOptions = {}) {
         utm_campaign VARCHAR(255),
         referrer TEXT,
         is_bot BOOLEAN NOT NULL DEFAULT false,
-        bot_reason VARCHAR(16)
+        bot_reason VARCHAR(16),
+        link_params JSONB
       )
     `);
 
@@ -518,6 +519,27 @@ export async function initializeDatabase(options: DatabaseOptions = {}) {
         END IF;
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='click_events' AND column_name='bot_reason') THEN
           ALTER TABLE click_events ADD COLUMN bot_reason VARCHAR(16);
+        END IF;
+      END $$;
+    `);
+
+    // Non-reserved query parameters carried on the click. A link can
+    // be shared with values on the URL — ?slug=titanic — that the app wants
+    // after a deferred install. Nothing else persists them, so today they are
+    // gone by the time the install is matched.
+    //
+    // Nullable with no default, and deliberately no index. On a table this size
+    // that keeps the change catalog-only: Postgres 11+ adds such a column
+    // without rewriting rows or holding a long lock. NOT NULL, a DEFAULT, or an
+    // index would each rewrite or scan the whole table.
+    //
+    // NULL for the overwhelming majority of clicks, which costs effectively
+    // nothing per row — the point, given how much this table already carries.
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='click_events' AND column_name='link_params') THEN
+          ALTER TABLE click_events ADD COLUMN link_params JSONB;
         END IF;
       END $$;
     `);


### PR DESCRIPTION
## Summary

Adds a nullable `link_params` JSONB column to `click_events`. **Nothing reads or writes it yet** — this is the schema half only, so it can land and be released independently of the behaviour that uses it.

First of three:

| | | |
|---|---|---|
| **SIT-410** | this PR | add the column |
| SIT-411 | next | capture non-reserved query params onto the click row |
| SIT-412 | after | deliver them in the deferred install payload |

## Why

A link shared with values on the URL — `?slug=titanic` — has nowhere to put them. `click_events` persists `utm_source/medium/campaign` and the fingerprint fields; everything else is discarded at redirect time. By the time a deferred install is matched back to that click, the values are gone.

This is the base-path-plus-parameters pattern AppsFlyer and Branch both support, and that AppsFlyer's own documentation recommends. It came out of a prospect asking whether LinkForty does the same.

## The one design decision

**Nullable, no default, no index — deliberately.**

`click_events` is the highest-volume table in the product, with a history of index bloat. A nullable column with no default is a catalog-only change in Postgres 11+: no row rewrite, no long lock, effectively free per row while the value stays NULL, which it will for the overwhelming majority of clicks.

`NOT NULL`, a `DEFAULT`, or an index would each rewrite or scan the entire table. Adding any of them later is a decision to make deliberately, with a plan — not something to slip in with the column.

Added in both places: the `CREATE TABLE` for fresh databases, and an idempotent `DO` block for existing ones, matching the pattern already used 23 times in this file.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **254 tests pass**, 15 files
- The new `DO` block was checked structurally against the 22 others in the file: guarded by `IF NOT EXISTS` on `information_schema.columns`, a single `ALTER TABLE`, no `NOT NULL`, no `DEFAULT`, no index

**Live-database check — now done.** Against a real Postgres:

```
column present before : 0
migrate run 1         : Database schema initialized successfully
migrate run 2         : Database schema initialized successfully   ← silent no-op, no error
```

`\d click_events` confirms the result:

```
 link_params  | jsonb  |  |  |          ← nullable, no default
Indexes:
    "idx_clicks_human_link_date" ...    ← pre-existing only; nothing on link_params
```

Idempotency, nullability, absence of a default and absence of an index are all confirmed on a live database rather than inferred.

## Out of scope

- Writing to the column (SIT-411) and reading it (SIT-412).
- Any index on `link_params` — see above.
- Cloud-side changes. Cloud picks this up with the next `@linkforty/core` release.

Closes SIT-410

