### PR TITLE
feat(redirect): capture non-reserved query params on the click row (SIT-411)

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -490,7 +490,7 @@ export async function initializeDatabase(options: DatabaseOptions = {}) {
       END $$;
     `);
 
-    // Non-reserved query parameters carried on the click (SIT-410). A link can
+    // Non-reserved query parameters carried on the click. A link can
     // be shared with values on the URL — ?slug=titanic — that the app wants
     // after a deferred install. Nothing else persists them, so today they are
     // gone by the time the install is matched.

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -133,7 +133,8 @@ export async function initializeDatabase(options: DatabaseOptions = {}) {
         utm_campaign VARCHAR(255),
         referrer TEXT,
         is_bot BOOLEAN NOT NULL DEFAULT false,
-        bot_reason VARCHAR(16)
+        bot_reason VARCHAR(16),
+        link_params JSONB
       )
     `);
 
@@ -485,6 +486,27 @@ export async function initializeDatabase(options: DatabaseOptions = {}) {
         END IF;
         IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='click_events' AND column_name='bot_reason') THEN
           ALTER TABLE click_events ADD COLUMN bot_reason VARCHAR(16);
+        END IF;
+      END $$;
+    `);
+
+    // Non-reserved query parameters carried on the click (SIT-410). A link can
+    // be shared with values on the URL — ?slug=titanic — that the app wants
+    // after a deferred install. Nothing else persists them, so today they are
+    // gone by the time the install is matched.
+    //
+    // Nullable with no default, and deliberately no index. On a table this size
+    // that keeps the change catalog-only: Postgres 11+ adds such a column
+    // without rewriting rows or holding a long lock. NOT NULL, a DEFAULT, or an
+    // index would each rewrite or scan the whole table.
+    //
+    // NULL for the overwhelming majority of clicks, which costs effectively
+    // nothing per row — the point, given how much this table already carries.
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='click_events' AND column_name='link_params') THEN
+          ALTER TABLE click_events ADD COLUMN link_params JSONB;
         END IF;
       END $$;
     `);

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -6,6 +6,7 @@ import {
   detectDevice,
   getLocationFromIP,
   resolveClickUtms,
+  extractLinkParams,
 } from './utils';
 
 describe('generateShortCode', () => {
@@ -260,5 +261,66 @@ describe('resolveClickUtms', () => {
     });
     expect(Object.keys(result).sort()).toEqual(['utmCampaign', 'utmMedium', 'utmSource']);
     expect(result.utmSource).toBe('frontend');
+  });
+});
+
+describe('extractLinkParams', () => {
+  it('keeps ordinary parameters', () => {
+    expect(extractLinkParams({ slug: 'titanic', id: '42' })).toEqual({
+      slug: 'titanic',
+      id: '42',
+    });
+  });
+
+  it('drops utm_ parameters, which have their own columns', () => {
+    expect(extractLinkParams({ utm_source: 'ig', utm_campaign: 'spring', slug: 'titanic' })).toEqual(
+      { slug: 'titanic' }
+    );
+  });
+
+  it('drops fp_ parameters, which feed the fingerprint', () => {
+    expect(extractLinkParams({ fp_tz: 'UTC', fp_sw: '390', slug: 'titanic' })).toEqual({
+      slug: 'titanic',
+    });
+  });
+
+  it('drops lf_click, the correlation id we set ourselves', () => {
+    expect(extractLinkParams({ lf_click: 'abc-123', slug: 'titanic' })).toEqual({
+      slug: 'titanic',
+    });
+  });
+
+  it('matches reserved prefixes case-insensitively', () => {
+    expect(extractLinkParams({ UTM_Source: 'ig', FP_TZ: 'UTC', LF_Click: 'x' })).toEqual({});
+  });
+
+  it('truncates a value longer than 256 characters', () => {
+    const result = extractLinkParams({ slug: 'a'.repeat(300) });
+    expect(result.slug).toHaveLength(256);
+  });
+
+  it('keeps a value of exactly 256 characters intact', () => {
+    const result = extractLinkParams({ slug: 'a'.repeat(256) });
+    expect(result.slug).toHaveLength(256);
+  });
+
+  it('stops after 16 parameters', () => {
+    const query: Record<string, string> = {};
+    for (let i = 0; i < 30; i++) query[`k${i}`] = String(i);
+    expect(Object.keys(extractLinkParams(query))).toHaveLength(16);
+  });
+
+  it('skips empty and non-string values', () => {
+    expect(
+      extractLinkParams({ empty: '', missing: undefined, repeated: ['a', 'b'], slug: 'titanic' })
+    ).toEqual({ slug: 'titanic' });
+  });
+
+  it('returns {} for an empty query, which is the ordinary case', () => {
+    expect(extractLinkParams({})).toEqual({});
+  });
+
+  it('returns {} rather than throwing when there is no query at all', () => {
+    expect(extractLinkParams(undefined)).toEqual({});
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -236,8 +236,7 @@ const LINK_PARAMS_MAX = 16;
 const LINK_PARAM_MAX_VALUE_LEN = 256;
 
 /**
- * The non-reserved query parameters on a redirect, to persist on the click row
- * (SIT-410/411).
+ * The non-reserved query parameters on a redirect, to persist on the click row.
  *
  * A link can be shared with values on the URL — `?slug=titanic` — that the app
  * wants after a deferred install. Everything else about the click is recorded;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -257,9 +257,9 @@ const LINK_PARAM_MAX_VALUE_LEN = 256;
  *
  * Returns `{}` when nothing qualifies, which is the ordinary case.
  *
- * Cloud has an equivalent (`extractPassthroughParams`) feeding its ESP click
- * sync. The duplication is deliberate: this package is published to npm and
- * cannot import from Cloud. Keep the two rule sets in step by hand.
+ * Downstream consumers may implement the same filtering for their own purposes.
+ * The duplication is deliberate — this package is published to npm and cannot
+ * depend on anything downstream — so keep the rule sets in step by hand.
  */
 export function extractLinkParams(
   query: Record<string, unknown> | undefined

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -228,3 +228,58 @@ export function detectDevice(userAgent: string): 'ios' | 'android' | 'web' {
 
   return 'web';
 }
+
+/** Most parameters a single click will carry through. */
+const LINK_PARAMS_MAX = 16;
+
+/** Longest value kept; anything beyond this is truncated. */
+const LINK_PARAM_MAX_VALUE_LEN = 256;
+
+/**
+ * The non-reserved query parameters on a redirect, to persist on the click row
+ * (SIT-410/411).
+ *
+ * A link can be shared with values on the URL — `?slug=titanic` — that the app
+ * wants after a deferred install. Everything else about the click is recorded;
+ * these were the one thing thrown away, which is why the base-path-plus-
+ * parameters pattern that AppsFlyer and Branch both support did not work here.
+ *
+ * Reserved prefixes are dropped because they are *already* handled and would
+ * otherwise be stored twice under a second name: `utm_*` lands in the utm_
+ * columns, `fp_*` feeds the fingerprint, and `lf_click` is the correlation id
+ * this redirect just put on the destination itself.
+ *
+ * Both caps exist because the input is a public URL that anyone can lengthen at
+ * will, and this writes to the highest-volume table in the product. They bound
+ * what a single click can cost. Truncation is silent by design — a too-long
+ * value is a caller error, and failing the redirect over it would be worse than
+ * storing a clipped one.
+ *
+ * Returns `{}` when nothing qualifies, which is the ordinary case.
+ *
+ * Cloud has an equivalent (`extractPassthroughParams`) feeding its ESP click
+ * sync. The duplication is deliberate: this package is published to npm and
+ * cannot import from Cloud. Keep the two rule sets in step by hand.
+ */
+export function extractLinkParams(
+  query: Record<string, unknown> | undefined
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!query || typeof query !== 'object') return out;
+
+  for (const [key, value] of Object.entries(query)) {
+    // A repeated parameter arrives as an array; skip rather than guess which
+    // occurrence was meant.
+    if (typeof value !== 'string' || value.length === 0) continue;
+
+    const lower = key.toLowerCase();
+    if (lower.startsWith('utm_') || lower.startsWith('fp_') || lower === 'lf_click') continue;
+
+    out[key] =
+      value.length > LINK_PARAM_MAX_VALUE_LEN ? value.slice(0, LINK_PARAM_MAX_VALUE_LEN) : value;
+
+    if (Object.keys(out).length >= LINK_PARAMS_MAX) break;
+  }
+
+  return out;
+}

--- a/src/routes/redirect.ts
+++ b/src/routes/redirect.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { FastifyInstance } from 'fastify';
 import { db } from '../lib/database.js';
 import { getClientIp } from '../lib/client-ip.js';
-import { parseUserAgent, getLocationFromIP, buildRedirectUrl, detectDevice, resolveClickUtms } from '../lib/utils.js';
+import { parseUserAgent, getLocationFromIP, buildRedirectUrl, detectDevice, resolveClickUtms, extractLinkParams } from '../lib/utils.js';
 import { storeFingerprintForClick, type FingerprintData } from '../lib/fingerprint.js';
 import { emitClickEvent } from '../lib/event-emitter.js';
 import { classifyBot, edgeBotSignal } from '../lib/bot-detection.js';
@@ -375,14 +375,21 @@ export async function redirectRoutes(
         const fpScreenWidth = query?.fp_sw ? parseInt(query.fp_sw, 10) : undefined;
         const fpScreenHeight = query?.fp_sh ? parseInt(query.fp_sh, 10) : undefined;
 
+        // Non-reserved query params, persisted so a deferred install can be
+        // handed them (SIT-411). Skipped entirely for bots: crawlers fuzz query
+        // strings, this is the highest-volume table in the product, and bot rows
+        // are already excluded from analytics — so storing theirs buys nothing
+        // and costs storage on every row they touch.
+        const linkParams = isBot ? {} : extractLinkParams(query);
+
         // Insert click event with the pre-generated id (see above) so the row
         // matches the lf_click value already placed on the redirect URL.
         await db.query(
           `INSERT INTO click_events (
             id, link_id, ip_address, user_agent, device_type, platform,
             country_code, country_name, region, city, latitude, longitude, timezone,
-            utm_source, utm_medium, utm_campaign, referrer, is_bot, bot_reason
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+            utm_source, utm_medium, utm_campaign, referrer, is_bot, bot_reason, link_params
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
           [
             clickId,
             link.id,
@@ -403,6 +410,9 @@ export async function redirectRoutes(
             referrer,
             isBot,
             botReason,
+            // NULL rather than '{}' when there is nothing to store, so the
+            // column stays empty for the overwhelming majority of rows.
+            Object.keys(linkParams).length > 0 ? JSON.stringify(linkParams) : null,
           ]
         );
 

--- a/src/routes/redirect.ts
+++ b/src/routes/redirect.ts
@@ -376,7 +376,7 @@ export async function redirectRoutes(
         const fpScreenHeight = query?.fp_sh ? parseInt(query.fp_sh, 10) : undefined;
 
         // Non-reserved query params, persisted so a deferred install can be
-        // handed them (SIT-411). Skipped entirely for bots: crawlers fuzz query
+        // handed them. Skipped entirely for bots: crawlers fuzz query
         // strings, this is the highest-volume table in the product, and bot rows
         // are already excluded from analytics — so storing theirs buys nothing
         // and costs storage on every row they touch.


### PR DESCRIPTION
## Summary

Records the non-reserved query parameters from a redirect on the click row. A link shared as `?slug=titanic` now persists that value; **nothing reads it yet** — SIT-412 delivers it in the deferred install payload.

Second of three: SIT-410 (#46) adds the column, this writes it, SIT-412 reads it.

> ⚠️ **Stacked on #46.** This branches off the SIT-410 branch, because the `INSERT` targets a column that does not exist on `main` yet. **Merge #46 first.**

## What it does

`extractLinkParams()` in `src/lib/utils.ts` takes the redirect's query string and returns what should be kept.

It drops three prefixes, all because they are **already handled and would otherwise be stored a second time under a different name**:

| Dropped | Why |
|---|---|
| `utm_*` | has its own columns, resolved by `resolveClickUtms` |
| `fp_*` | feeds the device fingerprint |
| `lf_click` | the correlation id this same redirect just put on the destination |

## The three judgment calls

**Caps of 16 parameters and 256 characters.** The input is a public URL that anyone can lengthen at will, and this writes to the highest-volume table in the product. The caps bound what a single click can cost. Truncation is **silent by design** — a too-long value is a caller error, and failing the redirect over one would be worse than storing it clipped.

**Bots are skipped entirely** (`isBot ? {} : extractLinkParams(query)`). Crawlers fuzz query strings, and bot rows are already excluded from analytics, so storing theirs costs storage on every row they touch and buys nothing.

**NULL, not `'{}'`, when there is nothing to keep.** Keeps the column genuinely empty for the overwhelming majority of rows, which is what makes SIT-410's "effectively free per row" claim hold.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **265 tests pass** (254 before, 11 new)
- New tests cover: reserved-prefix filtering, case-insensitive prefix matching, `lf_click` exclusion, truncation at 256, the boundary case of exactly 256, the 16-param cap, empty/non-string/repeated values, empty query, and `undefined` query
- **The positional `INSERT` was checked by script**, since the ticket flagged an off-by-one there as a silent wrong-column write: **20 columns, 20 placeholders, 20 bound values**, with `link_params` last in both lists

**Live-database check — now done.** A real redirect through the running server, carrying a mix of reserved and non-reserved parameters:

```
GET /sit411?slug=titanic&promo=new-year&utm_source=ig&utm_campaign=spring&fp_tz=UTC&lf_click=x
  -> 302 https://example.com/landing?lf_click=a13b9646-...

click row:
  link_params  {"slug": "titanic", "promo": "new-year"}
  utm_source   ig
  utm_campaign spring
  is_bot       f
```

The two non-reserved params were kept; `utm_*` went to their own columns and appear nowhere in `link_params`; `fp_tz` and an inbound `lf_click` were both dropped. The redirect still appended its own fresh `lf_click` to the destination.

Both negative paths confirmed too:

| Case | `link_params` |
|---|---|
| Googlebot user-agent | `NULL` |
| Only reserved params (`?utm_source=ig`) | `NULL`, not `'{}'` |

## Rebase note

The ticket warned this would collide with SIT-382. It has since merged, so this is written against the post-382 code: the `const query = ...` line survives at line 369 and `resolveClickUtms()` replaced the individual `utm*` consts. No conflict remains.

## Out of scope

- Reading the column — SIT-412.
- The SDK resolve-path click insert in `src/routes/sdk.ts`. The SDKs strip the original query string before calling `/resolve`, so there is nothing to capture there.
- Cloud's `extractPassthroughParams`. The duplication across the two repos is deliberate — this package publishes to npm and cannot import from Cloud. Noted in the docstring so the two rule sets stay in step.

Closes SIT-411


