### PR TITLE
feat(sdk): deliver captured click params in the deferred payload (SIT-412)

### DIFF
--- a/src/lib/deep-link-payload.test.ts
+++ b/src/lib/deep-link-payload.test.ts
@@ -162,3 +162,75 @@ describe('legacy install keys', () => {
     expect('deepLinkParameters' in payload).toBe(false);
   });
 });
+
+describe('toDeepLinkPayload — click params (SIT-412)', () => {
+  const link = { short_code: 'abc123' } as any;
+  const base = { clickedAt: '2026-09-09T00:00:00.000Z', isDeferred: true };
+
+  it('merges click params when the link has none configured', () => {
+    const p = toDeepLinkPayload(link, { ...base, linkParams: { slug: 'titanic' } });
+    expect(p.customParameters).toEqual({ slug: 'titanic' });
+  });
+
+  it('lets a click param override a configured one of the same name', () => {
+    const p = toDeepLinkPayload(
+      { ...link, deep_link_parameters: { slug: 'default', keep: 'me' } },
+      { ...base, linkParams: { slug: 'titanic' } }
+    );
+    expect(p.customParameters).toEqual({ slug: 'titanic', keep: 'me' });
+  });
+
+  it('leaves the payload untouched when there are no click params', () => {
+    const withParams = toDeepLinkPayload({ ...link, deep_link_parameters: { a: '1' } }, base);
+    expect(withParams.customParameters).toEqual({ a: '1' });
+
+    const withNone = toDeepLinkPayload(link, base);
+    expect(withNone.customParameters).toBeUndefined();
+  });
+
+  it('treats an empty click-param object as no params', () => {
+    const p = toDeepLinkPayload({ ...link, deep_link_parameters: { a: '1' } }, {
+      ...base,
+      linkParams: {},
+    });
+    expect(p.customParameters).toEqual({ a: '1' });
+  });
+
+  it('gives the legacy alias the same merged value as the canonical field', () => {
+    const p = toDeepLinkPayload(
+      { ...link, deep_link_parameters: { slug: 'default' } },
+      { ...base, linkParams: { slug: 'titanic' }, legacyInstallKeys: true }
+    );
+    // Deployed SDKs read deepLinkParameters in preference to customParameters,
+    // so the two disagreeing would make the merge invisible in the field.
+    expect(p.deepLinkParameters).toEqual(p.customParameters);
+    expect(p.deepLinkParameters).toEqual({ slug: 'titanic' });
+  });
+
+  it('keeps the legacy alias null when nothing is configured or carried', () => {
+    const p = toDeepLinkPayload(link, { ...base, legacyInstallKeys: true });
+    expect(p.deepLinkParameters).toBeNull();
+  });
+
+  it('does not throw when deep_link_parameters is null, a scalar or an array', () => {
+    for (const bad of [null, 'nope', 42, ['a', 'b']]) {
+      const p = toDeepLinkPayload({ ...link, deep_link_parameters: bad } as any, {
+        ...base,
+        linkParams: { slug: 'titanic' },
+      });
+      expect(p.customParameters).toEqual({ slug: 'titanic' });
+    }
+  });
+
+  it('introduces no key outside the canonical set', () => {
+    // The merge must land inside customParameters, never as a new top-level
+    // field — SDKs decode a fixed shape.
+    const p = toDeepLinkPayload(link, { ...base, linkParams: { slug: 'titanic' } });
+    const allowed = new Set<string>([
+      ...CANONICAL_DEEP_LINK_KEYS,
+      'confidenceScore',
+      'matchedFactors',
+    ]);
+    expect(Object.keys(p).filter((k) => !allowed.has(k))).toEqual([]);
+  });
+});

--- a/src/lib/deep-link-payload.test.ts
+++ b/src/lib/deep-link-payload.test.ts
@@ -163,7 +163,7 @@ describe('legacy install keys', () => {
   });
 });
 
-describe('toDeepLinkPayload — click params (SIT-412)', () => {
+describe('toDeepLinkPayload — click params', () => {
   const link = { short_code: 'abc123' } as any;
   const base = { clickedAt: '2026-09-09T00:00:00.000Z', isDeferred: true };
 
@@ -201,8 +201,8 @@ describe('toDeepLinkPayload — click params (SIT-412)', () => {
       { ...link, deep_link_parameters: { slug: 'default' } },
       { ...base, linkParams: { slug: 'titanic' }, legacyInstallKeys: true }
     );
-    // Deployed SDKs read deepLinkParameters in preference to customParameters,
-    // so the two disagreeing would make the merge invisible in the field.
+    // SDKs in the field read deepLinkParameters in preference to
+    // customParameters, so the two disagreeing would make the merge invisible.
     expect(p.deepLinkParameters).toEqual(p.customParameters);
     expect(p.deepLinkParameters).toEqual({ slug: 'titanic' });
   });

--- a/src/lib/deep-link-payload.ts
+++ b/src/lib/deep-link-payload.ts
@@ -49,7 +49,7 @@ export interface DeepLinkPayloadOptions {
    */
   legacyInstallKeys?: boolean;
   /**
-   * Non-reserved query parameters the click carried (SIT-411).
+   * Non-reserved query parameters the click carried.
    *
    * Merged over the link's configured `deep_link_parameters`. A value on the
    * URL wins on a key collision, matching how the inbound query string already
@@ -172,11 +172,11 @@ export function toDeepLinkPayload(
     payload.originalUrl = (link.original_url ?? null) as string | null;
     payload.webFallbackUrl = (link.web_fallback_url ?? null) as string | null;
     payload.targetingRules = link.targeting_rules ?? null;
-    // The same merged value, not the raw column. Deployed SDKs read this alias
-    // in *preference* to `customParameters` — mobile-sdk-react-native does
-    // `deepLinkParameters || customParameters` — so merging into the canonical
-    // field alone would be invisible to every React Native app in the field,
-    // which is the exact flow this feature exists for.
+    // The same merged value, not the raw column. SDKs in the field read this
+    // alias in *preference* to `customParameters`, falling back to the canonical
+    // name only when the alias is absent — so merging into the canonical field
+    // alone would be invisible to already-installed apps, which is the exact
+    // flow this serves.
     payload.deepLinkParameters = mergedParameters ?? null;
   }
 

--- a/src/lib/deep-link-payload.ts
+++ b/src/lib/deep-link-payload.ts
@@ -48,6 +48,15 @@ export interface DeepLinkPayloadOptions {
    * nulls included — until version telemetry shows the old readers are gone.
    */
   legacyInstallKeys?: boolean;
+  /**
+   * Non-reserved query parameters the click carried (SIT-411).
+   *
+   * Merged over the link's configured `deep_link_parameters`. A value on the
+   * URL wins on a key collision, matching how the inbound query string already
+   * beats link configuration for UTMs — what a sharer put on the URL is more
+   * specific than what the link was set up with.
+   */
+  linkParams?: Record<string, string> | null;
 }
 
 export interface DeepLinkPayload {
@@ -86,6 +95,20 @@ export const CANONICAL_DEEP_LINK_KEYS = [
   'isDeferred',
 ] as const;
 
+/**
+ * The link's configured parameters as a plain object, or undefined.
+ *
+ * `deep_link_parameters` is raw JSONB: it can be null, a scalar, or an array as
+ * easily as an object. Spreading one of those would throw inside the install
+ * path and take SDK initialization down with it, so it is guarded the same way
+ * `resolveClickUtms` guards `utm_parameters`.
+ */
+function asPlainObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
 function toIsoString(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : value;
 }
@@ -101,6 +124,18 @@ export function toDeepLinkPayload(
   link: DeepLinkLinkRow,
   options: DeepLinkPayloadOptions
 ): DeepLinkPayload {
+  // Configured parameters, with anything the click carried merged over the top.
+  // Computed once: the canonical field and the legacy alias below must never
+  // disagree, and deriving them separately is how they would.
+  const configured = asPlainObject(link.deep_link_parameters);
+  const clickParams =
+    options.linkParams && Object.keys(options.linkParams).length > 0
+      ? options.linkParams
+      : undefined;
+  const mergedParameters = clickParams
+    ? { ...(configured ?? {}), ...clickParams }
+    : link.deep_link_parameters;
+
   const payload: DeepLinkPayload = {
     shortCode: link.short_code,
     linkId: link.id || undefined,
@@ -110,7 +145,7 @@ export function toDeepLinkPayload(
     androidUrl: link.android_app_store_url || undefined,
     webUrl: link.web_fallback_url || undefined,
     utmParameters: link.utm_parameters || undefined,
-    customParameters: link.deep_link_parameters || undefined,
+    customParameters: mergedParameters || undefined,
     clickedAt: toIsoString(options.clickedAt),
     isDeferred: options.isDeferred,
   };
@@ -137,7 +172,12 @@ export function toDeepLinkPayload(
     payload.originalUrl = (link.original_url ?? null) as string | null;
     payload.webFallbackUrl = (link.web_fallback_url ?? null) as string | null;
     payload.targetingRules = link.targeting_rules ?? null;
-    payload.deepLinkParameters = link.deep_link_parameters ?? null;
+    // The same merged value, not the raw column. Deployed SDKs read this alias
+    // in *preference* to `customParameters` — mobile-sdk-react-native does
+    // `deepLinkParameters || customParameters` — so merging into the canonical
+    // field alone would be invisible to every React Native app in the field,
+    // which is the exact flow this feature exists for.
+    payload.deepLinkParameters = mergedParameters ?? null;
   }
 
   return payload;

--- a/src/lib/fingerprint.ts
+++ b/src/lib/fingerprint.ts
@@ -25,6 +25,12 @@ export interface FingerprintMatch {
   confidenceScore: number;
   matchedFactors: string[];
   clickedAt: Date;
+  /**
+   * Non-reserved query parameters the click carried (SIT-411). Null for every
+   * click recorded before that shipped, and for the ordinary click that carried
+   * none.
+   */
+  linkParams?: Record<string, string> | null;
 }
 
 /**
@@ -402,6 +408,7 @@ export async function matchInstallToClick(
        ce.id as click_id,
        ce.link_id,
        ce.clicked_at,
+       ce.link_params,
        l.attribution_window_hours,
        df.ip_address,
        df.user_agent,
@@ -466,6 +473,7 @@ export async function matchInstallToClick(
         confidenceScore: score,
         matchedFactors,
         clickedAt: new Date(row.clicked_at),
+        linkParams: row.link_params ?? null,
       };
     }
   }
@@ -618,6 +626,7 @@ export async function recordInstallEvent(
         isDeferred: true,
         confidenceScore: match.confidenceScore,
         matchedFactors: match.matchedFactors,
+        linkParams: match.linkParams,
         legacyInstallKeys: true,
       });
 

--- a/src/lib/fingerprint.ts
+++ b/src/lib/fingerprint.ts
@@ -26,7 +26,7 @@ export interface FingerprintMatch {
   matchedFactors: string[];
   clickedAt: Date;
   /**
-   * Non-reserved query parameters the click carried (SIT-411). Null for every
+   * Non-reserved query parameters the click carried. Null for every
    * click recorded before that shipped, and for the ordinary click that carried
    * none.
    */


### PR DESCRIPTION
## Summary

Hands the query parameters captured on a click to the app after a deferred install. A link shared as `?slug=titanic` now reaches the app on first open.

Last of three, and **the only one that changes what apps receive**:

| | | |
|---|---|---|
| SIT-410 | #46 | add the column |
| SIT-411 | #47 | capture params on the click row |
| **SIT-412** | this PR | deliver them in the install payload |

> ⚠️ **Stacked on #47, which is stacked on #46.** Merge in order: 46 → 47 → 48.

## The detail that decides whether this works at all

The merged value goes to **both** `customParameters` and the legacy `deepLinkParameters` alias, computed once so they cannot drift.

That is not belt-and-braces. Deployed SDKs read the alias **in preference to** the canonical field — `mobile-sdk-react-native/src/LinkFortySDK.ts:503-504` does `deepLinkParameters || customParameters`. Merging into `customParameters` alone would have been invisible to every React Native app in the field, in exactly the flow this feature exists for.

It also means **no SDK release is needed** for the deferred half. Apps already in the field pick this up as soon as Cloud adopts the core release.

## Precedence

Click params merge **over** the link's configured `deep_link_parameters`; the URL value wins on a key collision. Same rule the inbound query string already gets over link configuration for UTMs — what a sharer put on the URL is more specific than what the link was set up with.

## Safety

`deep_link_parameters` is raw JSONB and can be `null`, a scalar, or an array as easily as an object. Spreading one of those would throw inside the install path and take SDK initialization down with it, so it is guarded by `asPlainObject()` the same way `resolveClickUtms` guards `utm_parameters`. There is a test for each shape.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **273 tests pass** (265 before, 8 new)
- **`CANONICAL_DEEP_LINK_KEYS` diffed against `origin/main` — unchanged.** No new top-level key is introduced; the merge lands inside `customParameters`
- **`/resolve` passes no `linkParams`**, so direct-open responses are byte-identical to today
- Tests cover: merge with no configured params, click param overriding a configured one, no click params leaving the payload untouched, an empty click-param object treated as none, the legacy alias equalling the canonical field, the alias staying `null` when nothing exists, null/scalar/array `deep_link_parameters` not throwing, and no key outside the canonical set

One test I wrote initially asserted the key set was identical with and without a merge. That was wrong — a payload that gains parameters legitimately gains `customParameters`, which is deleted when empty. Rewritten to assert what the criterion actually meant: no key outside `CANONICAL_DEEP_LINK_KEYS` plus the two deferred-only fields.

**Live end-to-end check — now done.** A real click carrying `?slug=titanic&promo=new-year`, then a real install matched to it by fingerprint:

```json
{
  "attributed": true,
  "confidenceScore": 100,
  "matchedFactors": ["ip", "user_agent", "timezone", "language", "screen"],
  "deepLinkData": {
    "shortCode": "sit411",
    "isDeferred": true,
    "customParameters":   { "slug": "titanic", "promo": "new-year" },
    "deepLinkParameters": { "slug": "titanic", "promo": "new-year" }
  }
}
```

**The two keys are identical**, which is the property the whole change turns on — deployed React Native SDKs read `deepLinkParameters` in preference to `customParameters`, so the merge would be invisible in the field if they disagreed. No key outside the canonical set appears.

This is the prospect's exact scenario working: a base link shared with `?slug=titanic`, the value surviving an install, and arriving in the app payload.

*(Note for anyone reproducing this locally: attribution cannot succeed over loopback. IP is weighted 40 of 100 against a threshold of 70, and loopback is deliberately excluded as non-attributable, so a localhost click tops out at 60. The run above presented a routable IP via `TRUSTED_CLIENT_IP_HEADER`.)*

## What ships after this

Cloud picks the whole feature up with its next `@linkforty/core` bump. SIT-413 documents it, and is deliberately blocked until then so the docs cannot describe behaviour that is not released.

Closes SIT-412

