### PR TITLE
docs(changelog): remove a private tracker id from a release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.23.0 (2026-09-10)
 
-* feat(schema): add click_events.link_params (SIT-410) (#46) ([ebcf64a](https://github.com/LinkForty/core/commit/ebcf64a)), closes [#46](https://github.com/LinkForty/core/issues/46)
+* feat(schema): add click_events.link_params (#46) ([ebcf64a](https://github.com/LinkForty/core/commit/ebcf64a)), closes [#46](https://github.com/LinkForty/core/issues/46)
 
 ## <small>1.22.4 (2026-09-10)</small>
 


### PR DESCRIPTION
A release entry carried an id from a private tracker.

It got there through the squash-merge subject, which takes its text from the pull request title. This repository is public, so the id means nothing to a reader here — the same cleanup #45 applied to code comments and earlier changelog entries.

**Worth knowing for future PRs:** keep tracker ids out of PR *titles* in this repo. The title becomes the squash-merge subject, and semantic-release copies that verbatim into CHANGELOG.md. Comments and bodies are easy to scrub before merge; a generated changelog entry is not.

One further entry will need the same treatment: the most recent `feat(sdk)` commit still carries an id in its subject and its changelog line has not been generated yet.