### PR TITLE
docs(changelog): remove the remaining private tracker id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.25.0 (2026-09-10)
 
-* feat(sdk): deliver captured click params in the deferred payload (SIT-412) (#48) ([77d373f](https://github.com/LinkForty/core/commit/77d373f)), closes [#48](https://github.com/LinkForty/core/issues/48)
+* feat(sdk): deliver captured click params in the deferred payload (#48) ([77d373f](https://github.com/LinkForty/core/commit/77d373f)), closes [#48](https://github.com/LinkForty/core/issues/48)
 
 ## 1.24.0 (2026-09-10)
 


### PR DESCRIPTION
The last of them. Generated by the 1.25.0 release while the previous cleanup was in flight, from the same source — a squash-merge subject that inherited the id from a pull request title.

The changelog is clean after this. Keeping it clean means keeping tracker ids out of PR titles in this repository.